### PR TITLE
Fix grid control preference and OS X preference saving.

### DIFF
--- a/src/dialogs/PreferencesDialog.cpp
+++ b/src/dialogs/PreferencesDialog.cpp
@@ -29,14 +29,6 @@
 #   include "../xwordlua.hpp"
 #endif // XWORD_USE_LUA
 
-#ifdef __WXOSX__
-#   define XWORD_PREFERENCES_LIVE_PREVIEW 1
-#   define XWORD_PREFERENCES_SHRINK 1
-#else
-#   define XWORD_PREFERENCES_LIVE_PREVIEW 1
-#   define XWORD_PREFERENCES_SHRINK 0
-#endif
-
 
 extern int wxluatype_wxBookCtrlBase;
 
@@ -71,6 +63,7 @@ PreferencesDialog::PreferencesDialog(wxWindow * parent)
     LoadConfig();
 
     // Setup buttons
+    // On OS X, we update the preferences as they change, so we show no buttons.
 #ifndef __WXOSX__
 #   if XWORD_PREFERENCES_LIVE_PREVIEW
     CreateButtons(wxOK | wxCANCEL);

--- a/src/dialogs/PreferencesDialog.hpp
+++ b/src/dialogs/PreferencesDialog.hpp
@@ -22,6 +22,15 @@
 #include "../config.hpp" // For ConfigManager
 #include <wx/propdlg.h>
 
+#ifdef __WXOSX__
+#   define XWORD_PREFERENCES_LIVE_PREVIEW 1
+#   define XWORD_PREFERENCES_SHRINK 1
+#else
+#   define XWORD_PREFERENCES_LIVE_PREVIEW 1
+#   define XWORD_PREFERENCES_SHRINK 0
+#endif
+
+
 class PreferencesDialog : public wxPropertySheetDialog
 {
 protected:

--- a/src/dialogs/PreferencesPanel.cpp
+++ b/src/dialogs/PreferencesPanel.cpp
@@ -240,10 +240,9 @@ void SolvePanel::DoSaveConfig()
     long gridStyle = 0;
     if (m_moveAfterLetter->GetValue())
     {
+        gridStyle |= MOVE_AFTER_LETTER;
         if (m_nextBlank->GetValue())
             gridStyle |= MOVE_TO_NEXT_BLANK;
-        else
-            gridStyle |= MOVE_AFTER_LETTER;
     }
     if (m_blankOnDirection->GetValue())
         gridStyle |= BLANK_ON_DIRECTION;


### PR DESCRIPTION
Fixes #3.

When using MOVE_TO_NEXT_BLANK, MOVE_AFTER_LETTER must also be set, or
else the setting is ignored and the preference reset to unchecked when
the app is restarted.

Reverts commit 3670eff, which moved defines from hpp to cpp, because
PreferencesPanel.hpp depends on the value of
XWORD_PREFERENCES_LIVE_PREVIEW, which was undefined after this change.
We must define this variable somewhere accessible to both
PreferencesDialog.cpp and PreferencesPanel.hpp. This fixes live saving
of settings changes on OS X.