### PR TITLE
Make rebus square entry easier on macOS.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1409,7 +1409,8 @@ XGridCtrl::OnKeyDown(wxKeyEvent & evt)
         break;
     case WXK_INSERT:
     case WXK_NUMPAD_INSERT:
-        OnInsert(mod);
+    case WXK_ESCAPE:
+        OnRebusKey(mod);
         break;
     default:
         evt.Skip();
@@ -1729,7 +1730,7 @@ XGridCtrl::OnTab(int mod)
 
 // Allow entering multiple letters
 void
-XGridCtrl::OnInsert(int WXUNUSED(mod))
+XGridCtrl::OnRebusKey(int WXUNUSED(mod))
 {
     wxASSERT(! IsEmpty());
     if (! m_rebusCtrl)
@@ -1769,6 +1770,7 @@ XGridCtrl::EndRebusEntry(bool success)
         MoveAfterLetter();
     }
     RefreshSquare();
+    wxScrolledCanvas::SetFocus();
 }
 
 void

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -434,7 +434,7 @@ private:
     void OnEnd          (int mod);
     void OnBackspace    (int mod);
     void OnDelete       (int mod);
-    void OnInsert       (int mod);
+    void OnRebusKey     (int mod);
 
     DECLARE_EVENT_TABLE()
     DECLARE_NO_COPY_CLASS(XGridCtrl)

--- a/src/XGridRebus.cpp
+++ b/src/XGridRebus.cpp
@@ -42,6 +42,7 @@ protected:
     wxTextCtrl * m_text;
 
     void OnChar(wxKeyEvent & evt);
+    void OnKeyDown(wxKeyEvent & evt);
     void OnPaste(wxClipboardTextEvent & evt);
     void OnSelectAll(wxCommandEvent & evt);
     void OnInsert(wxCommandEvent & evt);
@@ -65,6 +66,8 @@ RebusTextCtrl::RebusTextCtrl(wxWindow * parent, XGridCtrl * grid)
 
     m_text->Connect(wxEVT_CHAR,
         wxKeyEventHandler(RebusTextCtrl::OnChar), NULL, this);
+    m_text->Connect(wxEVT_KEY_DOWN,
+        wxKeyEventHandler(RebusTextCtrl::OnKeyDown), NULL, this);
 
     // Accelerators
     wxAcceleratorEntry entries[1];
@@ -118,8 +121,6 @@ void RebusTextCtrl::OnChar(wxKeyEvent & evt)
     // Don't filter special keys
     if (code == WXK_RETURN || code == WXK_INSERT)
         m_grid->EndRebusEntry(); // end the rebus entry
-    else if (code == WXK_ESCAPE)
-        m_grid->EndRebusEntry(false); // user canceled
     else if (code < WXK_SPACE || code == WXK_DELETE || code > WXK_START)
         evt.Skip();
     else if (XGridCtrl::IsValidChar(code))
@@ -128,6 +129,14 @@ void RebusTextCtrl::OnChar(wxKeyEvent & evt)
         wxBell();
 }
 
+void RebusTextCtrl::OnKeyDown(wxKeyEvent & evt)
+{
+    int code = evt.GetKeyCode();
+    if (code == WXK_ESCAPE)
+        m_grid->EndRebusEntry(false); // user canceled
+    else
+        evt.Skip();
+}
 
 void RebusTextCtrl::OnPaste(wxClipboardTextEvent & evt)
 {


### PR DESCRIPTION
Fixes #9.

-Make Escape work like Insert for rebus entry. Macs don't generally
have insert keys, which makes it more difficult to enter rebus entries
on them. Across Lite supports Escape on Mac, and there is no conflict
(except during grid selection mode, where Escape cancels out of the
grid, which still works as expected).

-Ensure keyboard focus returns to the grid once the rebus control is
closed.

-Make Escape work (as intended) to dismiss the rebus control. The
listener was in OnChar, but we never receive an OnChar event for
WXK_ESCAPE. Instead, add a listener for OnKeyDown and move the escape
key handling there, as XGridCtrl does.