### PR TITLE
Fix crash in puzzles with alternate clue lists.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -879,6 +879,9 @@ MyFrame::ShowClues()
     if (no_clues)
         m_puz.GetClues().clear();
 
+    // Since the set of panes / pane captions may have changed, update the menu.
+    m_mgr.UpdateMenu();
+
     // Update the UI
     wxGetApp().GetConfigManager().Clue.Update();
 }

--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -879,8 +879,10 @@ MyFrame::ShowClues()
     if (no_clues)
         m_puz.GetClues().clear();
 
+#if USE_MY_AUI_MANAGER
     // Since the set of panes / pane captions may have changed, update the menu.
     m_mgr.UpdateMenu();
+#endif // USE_MY_AUI_MANAGER
 
     // Update the UI
     wxGetApp().GetConfigManager().Clue.Update();


### PR DESCRIPTION
Fixes #11.

When a puzzle uses something other than "Across" and "Down", e.g. a
marching bands puzzle with "Bands" and "Rows", we would update the
pane captions but not the corresponding menu items in View -> Panes.
This causes a crash when MyAuiMgr attempts to look up the pane for the
stale menu item "Across" and fails to match it by caption with the
pane for "Bands".

So, whenever we update the clue lists, update the menu as well.