### PR TITLE
Suppress grid clicks while "Paused" is rendered.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -177,6 +177,7 @@ void XGridCtrl::Init()
     m_isSelecting = false;
 
     m_isPaused = false;
+    m_isPausedRendered = false;
     m_fit = true;
 
     m_lastBoxSize = UNDEFINED_BOX_SIZE;
@@ -413,12 +414,14 @@ XGridCtrl::OnPaint(wxPaintEvent & WXUNUSED(evt))
         if (m_rebusCtrl && ! m_rebusCtrl->IsShown())
             m_rebusCtrl->Show();
         DrawGrid(dc, GetUpdateRegion());
+        m_isPausedRendered = false;
     }
     else
     {
         if (m_rebusCtrl && m_rebusCtrl->IsShown())
             m_rebusCtrl->Hide();
         DrawPauseMessage(dc);
+        m_isPausedRendered = true;
     }
 
     //wxScrolledWindow::SetFocus();
@@ -1286,7 +1289,8 @@ XGridCtrl::OnLeftDown(wxMouseEvent & evt)
 
     wxPoint pt = evt.GetPosition();
     puz::Square * square = HitTest(pt.x, pt.y);
-    if (square != NULL && (square->IsWhite() || GetGrid()->IsDiagramless()))
+    if (square != NULL && !m_isPausedRendered
+            && (square->IsWhite() || GetGrid()->IsDiagramless()))
         SetFocusedSquare(square);
 
     // Make sure to skip this event or we don't get keyboard focus!

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -387,6 +387,7 @@ protected:
     int m_lastBoxSize;          // The last non-fitted box size
     bool m_fit;                 // Fit the grid to the window?
     bool m_isPaused;            // Trigger a "Paused" message?
+    bool m_isPausedRendered;    // Is the "Paused" message currently showing?
 
     // Pointer to puzzle data
     puz::Puzzle * m_puz;


### PR DESCRIPTION
Fixes #13.

If focus is elsewhere and the grid is showing the "Paused" screen,
clicks should not be processed - the user cannot actually see where in
the grid they're clicking, so this can result in a disorienting change
in focus. The puzzle should be resumed exactly where the user left
off.

Note that it is not sufficient to check m_isPaused in OnLeftDown,
because the window activation event is processed before the mouse
click event. So we add a separate flag which reflects whether the
"Paused" screen is currently being rendered and only update this in
OnPaint when the user's view has actually changed.