### PR TITLE
Fix font size inconsistency in Mac color choice selectors.

### DIFF
--- a/src/dialogs/colorchoice.mm
+++ b/src/dialogs/colorchoice.mm
@@ -23,7 +23,7 @@ void ColorChoice::OSXUpdateAttributedStrings()
     NSArray *itemArray = [GetPeer()->GetWXWidget() itemArray];
     // The standard ctrl font size
     NSDictionary *attrs = [NSDictionary dictionaryWithObject:
-                                [NSFont controlContentFontOfSize: 0.0]
+                                [NSFont systemFontOfSize: 0.0]
                             forKey:NSFontAttributeName];
     for (int i = 1; i < [itemArray count]; i++) {
         NSMenuItem *item = [itemArray objectAtIndex:i];


### PR DESCRIPTION
Fixes #15.

Per the Apple developer documentation, systemFontOfSize is the font
used for standard interface items including menu items, so we should
use this size to ensure that our custom attribute labels (with colors)
are the same size as the default menu entry for "Other".