### PR TITLE
Make loose rebus checking more flexible.

### DIFF
--- a/puz/Square.cpp
+++ b/puz/Square.cpp
@@ -479,11 +479,10 @@ char_t Square::GetSolutionSymbol() const
 bool Square::Check(bool checkBlank, bool strictRebus)  const
 {
     // Black squares should be checked as well (for diagramless)
-
     if (IsBlank() && ! IsSolutionBlank())
         return ! checkBlank;
 
-    if (strictRebus || HasTextRebus())
+    if (strictRebus || (HasTextRebus() && HasSolutionRebus()))
         return m_solution == m_text;
     else
         return GetPlainText() == GetPlainSolution();


### PR DESCRIPTION
Fixes #17.

Many rebus solution grids don't actually have the rebus answers in
them, because the source format doesn't support them, or because the
puzzle creator doesn't know how to add them. When this happens, a
solver may enter the correct rebus solution, but it would be marked
wrong because the solution grid doesn't have the correct rebus answer.

So, if strict rebus checking is off, consider a rebus solution correct
if the solution has no rebus and the first letter of the user's
rebus solution matches the solution.