### PR TITLE
Fix brute force unscrambling when multiple keys work.

### DIFF
--- a/puz/Scrambler.cpp
+++ b/puz/Scrambler.cpp
@@ -196,8 +196,8 @@ Scrambler::ScrambleString(const std::string & str)
 // These are almost exactly the scrambling functions run backward
 //-----------------------------------------------------------------------------
 
-bool
-Scrambler::UnscrambleSolution(unsigned short key_int)
+std::string
+Scrambler::GetUnscrambledSolution(unsigned short key_int)
 {
     bool ok = m_grid.GetWidth() > 0 && m_grid.GetHeight() > 0;
     ok = ok && (m_grid.m_flag & FLAG_NO_SOLUTION) == 0;
@@ -206,7 +206,7 @@ Scrambler::UnscrambleSolution(unsigned short key_int)
     assert(m_grid.First() != NULL);
 
     if (! ok)
-        return false;
+        return "";
 
     // Read the key into an array of single digits
     unsigned char key[4];
@@ -221,7 +221,7 @@ Scrambler::UnscrambleSolution(unsigned short key_int)
 
     // Don't unscramble really small puzzles
     if(length < 12)
-        return 0;
+        return "";
 
     // Do the unscrambling
     for (int i = 3; i >= 0; --i)
@@ -254,7 +254,18 @@ Scrambler::UnscrambleSolution(unsigned short key_int)
     unsigned short cksum = Checksummer::cksum_region(solution, 0);
 
     if (cksum != m_grid.m_cksum)
+        return "";
+
+    return solution;
+}
+
+bool
+Scrambler::UnscrambleSolution(unsigned short key_int)
+{
+    std::string solution = GetUnscrambledSolution(key_int);
+    if (solution.empty()) {
         return false;
+    }
 
     // Save the unscrambled solution to the grid
     std::string::iterator it = solution.begin();

--- a/puz/Scrambler.hpp
+++ b/puz/Scrambler.hpp
@@ -36,6 +36,9 @@ public:
     // If key != 0, use the provided key, otherwise create one
     bool ScrambleSolution(unsigned short key_int = 0);
     bool UnscrambleSolution(unsigned short key_int);
+    // Return the unscrambled solution for the given key if it
+    // is valid, or else the empty string.
+    std::string GetUnscrambledSolution(unsigned short key_int);
 
     // Check a scrambled grid to see if it is correct
     static bool CheckUserGrid(const Grid & grid);

--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -3044,6 +3044,10 @@ private:
     }
 };
 
+bool isVowel(char x) {
+    return x == 'A' || x == 'E' || x == 'I' || x == 'O' || x == 'U';
+}
+
 void
 MyFrame::OnBruteForceUnscramble(wxCommandEvent & WXUNUSED(evt))
 {
@@ -3059,16 +3063,28 @@ MyFrame::OnBruteForceUnscramble(wxCommandEvent & WXUNUSED(evt))
     dlg->Show();
     puz::Scrambler scrambler(m_puz.GetGrid());
     unsigned short key = 0;
+    int maxCandidateVowels = 0;
     wxStopWatch sw;
     dlg->StartTimer();
     for (unsigned short i = 1000; i <= 9999; ++i)
     {
         wxTheApp->Yield(); // Don't block the GUI.
-        dlg->SetKey(i);
-        if (scrambler.UnscrambleSolution(i))
+        // Only update every 100 keys so rendering doesn't slow down the unscramble process.
+        if (i % 100 == 0) {
+            dlg->SetKey(i);
+        }
+        std::string solution = scrambler.GetUnscrambledSolution(i);
+        if (!solution.empty())
         {
-            key = i;
-            break;
+            // Some puzzles have more than one key which "unlocks" the puzzle, but only one key is
+            // valid, whereas the rest produce gibberish. As a rough heuristic, take the key whose
+            // resulting solution has the highest number of vowels.
+            int candidateVowels = std::count_if(solution.begin(), solution.end(), isVowel);
+            wxLogDebug(_T("Candidate key %d has %d vowels"), i, candidateVowels);
+            if (candidateVowels >= maxCandidateVowels) {
+                maxCandidateVowels = candidateVowels;
+                key = i;
+            }
         }
     }
     // If we don't stop the timer, it might try to send another event, which would
@@ -3087,6 +3103,7 @@ MyFrame::OnBruteForceUnscramble(wxCommandEvent & WXUNUSED(evt))
     }
     else
     {
+        assert(scrambler.UnscrambleSolution(key));
         wxMessageBox(wxString::Format(
                         _T("Unscrambling succeeded!\n")
                         _T("Key: %d\n")


### PR DESCRIPTION
Fixes #19.

In some puzzles, multiple keys appear to result in a matching
checksum, but all but one will produce gibberish. Thus, as a rough
heuristic, we count the number of vowels in each unscrambled solution,
and unscramble using the solution with the most vowels.

Unfortunately, this means we must try every key instead of short-
circuiting when we find a valid one. Trying every key should only
takes a couple seconds, except that on Mac, UnscrambleDialog performs
quite slowly due to the frequent text updates. Speed up unscrambling
by limiting dialog updates to every 100th key.