### PR TITLE
Move the timer slightly left to prevent truncation.

### DIFF
--- a/src/MyStatusBar.cpp
+++ b/src/MyStatusBar.cpp
@@ -50,9 +50,9 @@ MyStatusBar::MyStatusBar(wxWindow * parent,
     : wxStatusBar(parent, id, style, name)
 {
 #ifdef XWORD_USE_LUA
-    int widths[] = {-2, 150, 200, 100};
+    int widths[] = {-2, 150, 200, 110};
 #else
-    int widths[] = {-2, 200, 100};
+    int widths[] = {-2, 200, 110};
 #endif // XWORD_USE_LUA
 
     SetFieldsCount(STATUS_TOTAL, widths);


### PR DESCRIPTION
Quick hack for issue #6, since right-aligning the timer is
non-trivial.