### PR TITLE
Regenerate wxFormBuilder code.

### DIFF
--- a/src/dialogs/wxFB_Dialogs.cpp
+++ b/src/dialogs/wxFB_Dialogs.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Nov  6 2013)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -17,7 +17,6 @@ LicenseDialog::LicenseDialog( wxWindow* parent, wxWindowID id, const wxString& t
 	bSizer22 = new wxBoxSizer( wxVERTICAL );
 	
 	m_textCtrl = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), wxTE_MULTILINE|wxTE_READONLY );
-	m_textCtrl->SetMaxLength( 0 ); 
 	bSizer22->Add( m_textCtrl, 1, wxALL|wxEXPAND, 10 );
 	
 	m_sdbSizer2 = new wxStdDialogButtonSizer();
@@ -65,22 +64,22 @@ CustomPrintDialogBase::CustomPrintDialogBase( wxWindow* parent, wxWindowID id, c
 	wxStaticBoxSizer* sbSizer13;
 	sbSizer13 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Puzzle") ), wxVERTICAL );
 	
-	m_grid = new wxCheckBox( this, wxID_ANY, wxT("Grid"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_grid = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Grid"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer13->Add( m_grid, 1, wxALL|wxEXPAND, 5 );
 	
 	wxBoxSizer* bSizer21;
 	bSizer21 = new wxBoxSizer( wxVERTICAL );
 	
-	m_numbers = new wxCheckBox( this, wxID_ANY, wxT("Numbers"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_numbers = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Numbers"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer21->Add( m_numbers, 1, wxALL|wxEXPAND, 5 );
 	
-	m_text = new wxCheckBox( this, wxID_ANY, wxT("Text"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_text = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Text"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer21->Add( m_text, 1, wxALL|wxEXPAND, 5 );
 	
-	m_solution = new wxCheckBox( this, wxID_ANY, wxT("Solution"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_solution = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Solution"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer21->Add( m_solution, 1, wxALL|wxEXPAND, 5 );
 	
-	m_theme = new wxCheckBox( this, wxID_ANY, wxT("Highlight Theme"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_theme = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Highlight Theme"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_theme->Hide();
 	
 	bSizer21->Add( m_theme, 0, wxALL, 5 );
@@ -88,7 +87,7 @@ CustomPrintDialogBase::CustomPrintDialogBase( wxWindow* parent, wxWindowID id, c
 	
 	sbSizer13->Add( bSizer21, 3, wxLEFT|wxEXPAND, 25 );
 	
-	m_clues = new wxCheckBox( this, wxID_ANY, wxT("Clues"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_clues = new wxCheckBox( sbSizer13->GetStaticBox(), wxID_ANY, wxT("Clues"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer13->Add( m_clues, 1, wxALL|wxEXPAND, 5 );
 	
 	
@@ -100,13 +99,13 @@ CustomPrintDialogBase::CustomPrintDialogBase( wxWindow* parent, wxWindowID id, c
 	wxStaticBoxSizer* sbSizer12;
 	sbSizer12 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Header") ), wxVERTICAL );
 	
-	m_title = new wxCheckBox( this, wxID_ANY, wxT("Title"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_title = new wxCheckBox( sbSizer12->GetStaticBox(), wxID_ANY, wxT("Title"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer12->Add( m_title, 0, wxALL|wxEXPAND, 5 );
 	
-	m_author = new wxCheckBox( this, wxID_ANY, wxT("Author"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_author = new wxCheckBox( sbSizer12->GetStaticBox(), wxID_ANY, wxT("Author"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer12->Add( m_author, 0, wxALL|wxEXPAND, 5 );
 	
-	m_notes = new wxCheckBox( this, wxID_ANY, wxT("Notes"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_notes = new wxCheckBox( sbSizer12->GetStaticBox(), wxID_ANY, wxT("Notes"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer12->Add( m_notes, 0, wxALL, 5 );
 	
 	

--- a/src/dialogs/wxFB_Dialogs.fbp
+++ b/src/dialogs/wxFB_Dialogs.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -480,6 +480,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer13</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -1042,6 +1043,7 @@
                                         <property name="minimum_size"></property>
                                         <property name="name">sbSizer12</property>
                                         <property name="orient">wxVERTICAL</property>
+                                        <property name="parent">1</property>
                                         <property name="permission">none</property>
                                         <event name="OnUpdateUI"></event>
                                         <object class="sizeritem" expanded="0">

--- a/src/dialogs/wxFB_Dialogs.h
+++ b/src/dialogs/wxFB_Dialogs.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Nov  6 2013)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!

--- a/src/dialogs/wxFB_MetadataFormat.cpp
+++ b/src/dialogs/wxFB_MetadataFormat.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -24,19 +24,18 @@ wxFB_MetadataFormatDialog::wxFB_MetadataFormatDialog( wxWindow* parent, wxWindow
 	
 	m_functionStart = new wxStaticText( m_panel5, wxID_ANY, wxT("function(puzzle)"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_functionStart->Wrap( -1 );
-	m_functionStart->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 75, 90, 90, false, wxT("Consolas") ) );
+	m_functionStart->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxT("Consolas") ) );
 	
 	m_sizer->Add( m_functionStart, 0, wxBOTTOM, 5 );
 	
 	m_format = new wxTextCtrl( m_panel5, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_DONTWRAP|wxTE_MULTILINE );
-	m_format->SetMaxLength( 0 ); 
-	m_format->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 75, 90, 90, false, wxT("Consolas") ) );
+	m_format->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxT("Consolas") ) );
 	
 	m_sizer->Add( m_format, 1, wxEXPAND|wxLEFT, 15 );
 	
 	m_functionEnd = new wxStaticText( m_panel5, wxID_ANY, wxT("end"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_functionEnd->Wrap( -1 );
-	m_functionEnd->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 75, 90, 90, false, wxT("Consolas") ) );
+	m_functionEnd->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxT("Consolas") ) );
 	
 	m_sizer->Add( m_functionEnd, 0, wxTOP, 5 );
 	
@@ -46,7 +45,7 @@ wxFB_MetadataFormatDialog::wxFB_MetadataFormatDialog( wxWindow* parent, wxWindow
 	wxStaticBoxSizer* sbSizer12;
 	sbSizer12 = new wxStaticBoxSizer( new wxStaticBox( m_panel5, wxID_ANY, wxT("Result") ), wxVERTICAL );
 	
-	m_result = new wxStaticText( m_panel5, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+	m_result = new wxStaticText( sbSizer12->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	m_result->Wrap( -1 );
 	sbSizer12->Add( m_result, 0, wxALL, 5 );
 	
@@ -100,7 +99,7 @@ wxFB_MetadataFormatHelpPanel::wxFB_MetadataFormatHelpPanel( wxWindow* parent, wx
 	
 	m_text1 = new wxStaticText( this, wxID_ANY, wxT("Format Help"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_text1->Wrap( -1 );
-	m_text1->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_text1->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer14->Add( m_text1, 0, wxALL, 5 );
 	

--- a/src/dialogs/wxFB_MetadataFormat.fbp
+++ b/src/dialogs/wxFB_MetadataFormat.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -20,8 +20,10 @@
         <property name="path">.</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
+        <property name="skip_lua_events">1</property>
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
+        <property name="ui_table">UI</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Frame" expanded="1">
@@ -538,6 +540,7 @@
                                             <property name="minimum_size"></property>
                                             <property name="name">sbSizer12</property>
                                             <property name="orient">wxVERTICAL</property>
+                                            <property name="parent">1</property>
                                             <property name="permission">none</property>
                                             <event name="OnUpdateUI"></event>
                                             <object class="sizeritem" expanded="0">

--- a/src/dialogs/wxFB_MetadataFormat.h
+++ b/src/dialogs/wxFB_MetadataFormat.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!

--- a/src/dialogs/wxFB_PreferencesPanels.cpp
+++ b/src/dialogs/wxFB_PreferencesPanels.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -20,7 +20,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer411;
 	sbSizer411 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Timer") ), wxVERTICAL );
 	
-	m_startTimer = new wxCheckBox( this, wxID_ANY, wxT("Start when a puzzle is opened"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_startTimer = new wxCheckBox( sbSizer411->GetStaticBox(), wxID_ANY, wxT("Start when a puzzle is opened"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_startTimer->SetValue(true); 
 	sbSizer411->Add( m_startTimer, 0, wxALL, 5 );
 	
@@ -30,43 +30,43 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer3;
 	sbSizer3 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Cursor movement") ), wxVERTICAL );
 	
-	m_moveAfterLetter = new wxCheckBox( this, wxID_ANY, wxT("Move after entering a letter"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_moveAfterLetter = new wxCheckBox( sbSizer3->GetStaticBox(), wxID_ANY, wxT("Move after entering a letter"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_moveAfterLetter->SetValue(true); 
 	sbSizer3->Add( m_moveAfterLetter, 0, wxALL, 5 );
 	
 	wxBoxSizer* bSizer12;
 	bSizer12 = new wxBoxSizer( wxVERTICAL );
 	
-	m_nextSquare = new wxRadioButton( this, wxID_ANY, wxT("To the next square"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_nextSquare = new wxRadioButton( sbSizer3->GetStaticBox(), wxID_ANY, wxT("To the next square"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer12->Add( m_nextSquare, 0, wxALL, 5 );
 	
-	m_nextBlank = new wxRadioButton( this, wxID_ANY, wxT("To the next blank square"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_nextBlank = new wxRadioButton( sbSizer3->GetStaticBox(), wxID_ANY, wxT("To the next blank square"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer12->Add( m_nextBlank, 0, wxALL, 5 );
 	
 	
 	sbSizer3->Add( bSizer12, 0, wxLEFT, 20 );
 	
-	m_staticText10 = new wxStaticText( this, wxID_ANY, wxT("Move to a blank square"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText10 = new wxStaticText( sbSizer3->GetStaticBox(), wxID_ANY, wxT("Move to a blank square"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText10->Wrap( -1 );
 	sbSizer3->Add( m_staticText10, 0, wxALL, 5 );
 	
 	wxBoxSizer* bSizer13;
 	bSizer13 = new wxBoxSizer( wxVERTICAL );
 	
-	m_blankOnDirection = new wxCheckBox( this, wxID_ANY, wxT("After switching directions"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_blankOnDirection = new wxCheckBox( sbSizer3->GetStaticBox(), wxID_ANY, wxT("After switching directions"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer13->Add( m_blankOnDirection, 0, wxALL, 5 );
 	
-	m_blankOnNewWord = new wxCheckBox( this, wxID_ANY, wxT("After moving to a new word"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_blankOnNewWord = new wxCheckBox( sbSizer3->GetStaticBox(), wxID_ANY, wxT("After moving to a new word"), wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer13->Add( m_blankOnNewWord, 0, wxALL, 5 );
 	
 	
 	sbSizer3->Add( bSizer13, 0, wxLEFT, 20 );
 	
-	m_pauseOnSwitch = new wxCheckBox( this, wxID_ANY, wxT("Pause when switching direction"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_pauseOnSwitch = new wxCheckBox( sbSizer3->GetStaticBox(), wxID_ANY, wxT("Pause when switching direction"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_pauseOnSwitch->SetValue(true); 
 	sbSizer3->Add( m_pauseOnSwitch, 0, wxALL, 5 );
 	
-	m_moveOnRightClick = new wxCheckBox( this, wxID_ANY, wxT("Move to mouse on right click"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_moveOnRightClick = new wxCheckBox( sbSizer3->GetStaticBox(), wxID_ANY, wxT("Move to mouse on right click"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_moveOnRightClick->SetValue(true); 
 	sbSizer3->Add( m_moveOnRightClick, 0, wxALL, 5 );
 	
@@ -82,10 +82,10 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer41;
 	sbSizer41 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Solution") ), wxVERTICAL );
 	
-	m_checkWhileTyping = new wxCheckBox( this, wxID_ANY, wxT("Check solution while typing"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_checkWhileTyping = new wxCheckBox( sbSizer41->GetStaticBox(), wxID_ANY, wxT("Check solution while typing"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer41->Add( m_checkWhileTyping, 0, wxALL, 5 );
 	
-	m_strictRebus = new wxCheckBox( this, wxID_ANY, wxT("Strict rebus checking"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_strictRebus = new wxCheckBox( sbSizer41->GetStaticBox(), wxID_ANY, wxT("Strict rebus checking"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_strictRebus->SetToolTip( wxT("Require rebus entries to exactly match the solution") );
 	
 	sbSizer41->Add( m_strictRebus, 0, wxALL, 5 );
@@ -96,11 +96,11 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer22;
 	sbSizer22 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("File history") ), wxVERTICAL );
 	
-	m_saveFileHistory = new wxCheckBox( this, wxID_ANY, wxT("Save a history of recent puzzles"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_saveFileHistory = new wxCheckBox( sbSizer22->GetStaticBox(), wxID_ANY, wxT("Save a history of recent puzzles"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_saveFileHistory->SetValue(true); 
 	sbSizer22->Add( m_saveFileHistory, 0, wxALL, 5 );
 	
-	m_reopenLastPuzzle = new wxCheckBox( this, wxID_ANY, wxT("Open last puzzle on startup"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_reopenLastPuzzle = new wxCheckBox( sbSizer22->GetStaticBox(), wxID_ANY, wxT("Open last puzzle on startup"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_reopenLastPuzzle->SetValue(true); 
 	sbSizer22->Add( m_reopenLastPuzzle, 0, wxALL, 5 );
 	
@@ -110,21 +110,21 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer4111;
 	sbSizer4111 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Auto Save") ), wxVERTICAL );
 	
-	m_useAutoSave = new wxCheckBox( this, wxID_ANY, wxT("Automatically save puzzles"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_useAutoSave = new wxCheckBox( sbSizer4111->GetStaticBox(), wxID_ANY, wxT("Automatically save puzzles"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_useAutoSave->SetValue(true); 
 	sbSizer4111->Add( m_useAutoSave, 0, wxALL, 5 );
 	
 	wxBoxSizer* bSizer24;
 	bSizer24 = new wxBoxSizer( wxHORIZONTAL );
 	
-	m_stAfter = new wxStaticText( this, wxID_ANY, wxT("After"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_stAfter = new wxStaticText( sbSizer4111->GetStaticBox(), wxID_ANY, wxT("After"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stAfter->Wrap( -1 );
 	bSizer24->Add( m_stAfter, 0, wxALIGN_CENTER_VERTICAL|wxLEFT, 5 );
 	
-	m_autoSave = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 40,-1 ), wxSP_ARROW_KEYS, 0, 99, 10 );
+	m_autoSave = new wxSpinCtrl( sbSizer4111->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 40,-1 ), wxSP_ARROW_KEYS, 0, 99, 10 );
 	bSizer24->Add( m_autoSave, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	
-	m_stSeconds = new wxStaticText( this, wxID_ANY, wxT("seconds"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_stSeconds = new wxStaticText( sbSizer4111->GetStaticBox(), wxID_ANY, wxT("seconds"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_stSeconds->Wrap( -1 );
 	bSizer24->Add( m_stSeconds, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5 );
 	
@@ -206,7 +206,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer14;
 	sbSizer14 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Fonts") ), wxVERTICAL );
 	
-	m_printCustomFonts = new wxCheckBox( this, wxID_ANY, wxT("Use custom fonts"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_printCustomFonts = new wxCheckBox( sbSizer14->GetStaticBox(), wxID_ANY, wxT("Use custom fonts"), wxDefaultPosition, wxDefaultSize, 0 );
 	sbSizer14->Add( m_printCustomFonts, 0, wxALL, 8 );
 	
 	wxFlexGridSizer* fgSizer5;
@@ -215,7 +215,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	fgSizer5->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 	
 	wxStaticText* m_staticText144;
-	m_staticText144 = new wxStaticText( this, wxID_ANY, wxT("Grid Text:"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText144 = new wxStaticText( sbSizer14->GetStaticBox(), wxID_ANY, wxT("Grid Text:"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText144->Wrap( -1 );
 	fgSizer5->Add( m_staticText144, 0, wxALIGN_CENTER_VERTICAL, 5 );
 	
@@ -223,7 +223,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	fgSizer5->Add( m_printGridLetterFont, 0, 0, 5 );
 	
 	wxStaticText* m_printGridNumberFontLabel;
-	m_printGridNumberFontLabel = new wxStaticText( this, wxID_ANY, wxT("Grid Numbers:"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_printGridNumberFontLabel = new wxStaticText( sbSizer14->GetStaticBox(), wxID_ANY, wxT("Grid Numbers:"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_printGridNumberFontLabel->Wrap( -1 );
 	fgSizer5->Add( m_printGridNumberFontLabel, 0, wxALIGN_CENTER_VERTICAL, 5 );
 	
@@ -231,7 +231,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	fgSizer5->Add( m_printGridNumberFont, 0, 0, 5 );
 	
 	wxStaticText* m_staticText1412;
-	m_staticText1412 = new wxStaticText( this, wxID_ANY, wxT("Clues:"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText1412 = new wxStaticText( sbSizer14->GetStaticBox(), wxID_ANY, wxT("Clues:"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText1412->Wrap( -1 );
 	fgSizer5->Add( m_staticText1412, 0, wxALIGN_CENTER_VERTICAL, 5 );
 	
@@ -253,16 +253,16 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxGridSizer* gSizer1;
 	gSizer1 = new wxGridSizer( 0, 2, 0, 0 );
 	
-	m_alignTL = new wxRadioButton( this, wxID_ANY, wxT("Top left"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_alignTL = new wxRadioButton( sbSizer8->GetStaticBox(), wxID_ANY, wxT("Top left"), wxDefaultPosition, wxDefaultSize, 0 );
 	gSizer1->Add( m_alignTL, 0, wxALL, 5 );
 	
-	m_alignTR = new wxRadioButton( this, wxID_ANY, wxT("Top right"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_alignTR = new wxRadioButton( sbSizer8->GetStaticBox(), wxID_ANY, wxT("Top right"), wxDefaultPosition, wxDefaultSize, 0 );
 	gSizer1->Add( m_alignTR, 0, wxALL, 5 );
 	
-	m_alignBL = new wxRadioButton( this, wxID_ANY, wxT("Bottom left"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_alignBL = new wxRadioButton( sbSizer8->GetStaticBox(), wxID_ANY, wxT("Bottom left"), wxDefaultPosition, wxDefaultSize, 0 );
 	gSizer1->Add( m_alignBL, 0, wxALL, 5 );
 	
-	m_alignBR = new wxRadioButton( this, wxID_ANY, wxT("Bottom right"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_alignBR = new wxRadioButton( sbSizer8->GetStaticBox(), wxID_ANY, wxT("Bottom right"), wxDefaultPosition, wxDefaultSize, 0 );
 	gSizer1->Add( m_alignBR, 0, wxALL, 5 );
 	
 	
@@ -274,18 +274,18 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticBoxSizer* sbSizer19;
 	sbSizer19 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Black square brightness") ), wxHORIZONTAL );
 	
-	m_staticText13 = new wxStaticText( this, wxID_ANY, wxT("White"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText13 = new wxStaticText( sbSizer19->GetStaticBox(), wxID_ANY, wxT("White"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText13->Wrap( -1 );
 	sbSizer19->Add( m_staticText13, 0, wxTOP|wxBOTTOM|wxLEFT|wxALIGN_CENTER_VERTICAL, 5 );
 	
-	m_printBlackSquareBrightness = new wxSlider( this, wxID_ANY, 0, 0, 255, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL|wxSL_INVERSE );
+	m_printBlackSquareBrightness = new wxSlider( sbSizer19->GetStaticBox(), wxID_ANY, 0, 0, 255, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL|wxSL_INVERSE );
 	sbSizer19->Add( m_printBlackSquareBrightness, 1, wxTOP|wxALIGN_CENTER_VERTICAL, 3 );
 	
-	m_staticText14 = new wxStaticText( this, wxID_ANY, wxT("Black"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText14 = new wxStaticText( sbSizer19->GetStaticBox(), wxID_ANY, wxT("Black"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText14->Wrap( -1 );
 	sbSizer19->Add( m_staticText14, 0, wxTOP|wxBOTTOM|wxRIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 	
-	m_panel8 = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), wxSUNKEN_BORDER );
+	m_panel8 = new wxPanel( sbSizer19->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), wxSUNKEN_BORDER );
 	wxBoxSizer* bSizer21;
 	bSizer21 = new wxBoxSizer( wxVERTICAL );
 	

--- a/src/dialogs/wxFB_PreferencesPanels.fbp
+++ b/src/dialogs/wxFB_PreferencesPanels.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -20,8 +20,10 @@
         <property name="path">.</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
+        <property name="skip_lua_events">1</property>
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
+        <property name="ui_table">UI</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Panel" expanded="0">
@@ -100,6 +102,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer411</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -202,6 +205,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer3</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -948,6 +952,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer41</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -1138,6 +1143,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer22</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -1328,6 +1334,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer4111</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">
@@ -1594,6 +1601,7 @@
                                                 <event name="OnSize"></event>
                                                 <event name="OnSpinCtrl"></event>
                                                 <event name="OnSpinCtrlText"></event>
+                                                <event name="OnTextEnter"></event>
                                                 <event name="OnUpdateUI"></event>
                                             </object>
                                         </object>
@@ -2011,6 +2019,7 @@
                         <property name="minimum_size"></property>
                         <property name="name">sbSizer14</property>
                         <property name="orient">wxVERTICAL</property>
+                        <property name="parent">1</property>
                         <property name="permission">none</property>
                         <event name="OnUpdateUI"></event>
                         <object class="sizeritem" expanded="0">
@@ -2644,6 +2653,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer8</property>
                                 <property name="orient">wxVERTICAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="1">
@@ -3024,6 +3034,7 @@
                                 <property name="minimum_size"></property>
                                 <property name="name">sbSizer19</property>
                                 <property name="orient">wxHORIZONTAL</property>
+                                <property name="parent">1</property>
                                 <property name="permission">none</property>
                                 <event name="OnUpdateUI"></event>
                                 <object class="sizeritem" expanded="0">

--- a/src/dialogs/wxFB_PreferencesPanels.h
+++ b/src/dialogs/wxFB_PreferencesPanels.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!

--- a/src/dialogs/wxFB_PreferencesPanelsOSX.cpp
+++ b/src/dialogs/wxFB_PreferencesPanelsOSX.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -23,7 +23,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText911;
 	m_staticText911 = new wxStaticText( this, wxID_ANY, wxT("Timer"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText911->Wrap( -1 );
-	m_staticText911->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText911->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer411->Add( m_staticText911, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -45,7 +45,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText91;
 	m_staticText91 = new wxStaticText( this, wxID_ANY, wxT("Solution"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText91->Wrap( -1 );
-	m_staticText91->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText91->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer41->Add( m_staticText91, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -72,7 +72,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText9;
 	m_staticText9 = new wxStaticText( this, wxID_ANY, wxT("Cursor Movement"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText9->Wrap( -1 );
-	m_staticText9->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText9->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer4->Add( m_staticText9, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -122,7 +122,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText92;
 	m_staticText92 = new wxStaticText( this, wxID_ANY, wxT("Auto Saving"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText92->Wrap( -1 );
-	m_staticText92->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText92->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer42->Add( m_staticText92, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -162,7 +162,7 @@ wxFB_SolvePanel::wxFB_SolvePanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText921;
 	m_staticText921 = new wxStaticText( this, wxID_ANY, wxT("File History"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText921->Wrap( -1 );
-	m_staticText921->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText921->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer421->Add( m_staticText921, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -260,7 +260,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText911;
 	m_staticText911 = new wxStaticText( this, wxID_ANY, wxT("Fonts"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText911->Wrap( -1 );
-	m_staticText911->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText911->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer411->Add( m_staticText911, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -314,7 +314,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText9111;
 	m_staticText9111 = new wxStaticText( this, wxID_ANY, wxT("Grid Alignment"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText9111->Wrap( -1 );
-	m_staticText9111->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText9111->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer4111->Add( m_staticText9111, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -346,7 +346,7 @@ wxFB_PrintPanel::wxFB_PrintPanel( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText91111;
 	m_staticText91111 = new wxStaticText( this, wxID_ANY, wxT("Black Square Color"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText91111->Wrap( -1 );
-	m_staticText91111->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_staticText91111->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString ) );
 	
 	bSizer41111->Add( m_staticText91111, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	

--- a/src/dialogs/wxFB_PreferencesPanelsOSX.fbp
+++ b/src/dialogs/wxFB_PreferencesPanelsOSX.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -20,8 +20,10 @@
         <property name="path">.</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
+        <property name="skip_lua_events">1</property>
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
+        <property name="ui_table">UI</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Panel" expanded="1">
@@ -1661,6 +1663,7 @@
                                                         <event name="OnSize"></event>
                                                         <event name="OnSpinCtrl"></event>
                                                         <event name="OnSpinCtrlText"></event>
+                                                        <event name="OnTextEnter"></event>
                                                         <event name="OnUpdateUI"></event>
                                                     </object>
                                                 </object>

--- a/src/dialogs/wxFB_PreferencesPanelsOSX.h
+++ b/src/dialogs/wxFB_PreferencesPanelsOSX.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!

--- a/src/dialogs/wxFB_TreePanels.cpp
+++ b/src/dialogs/wxFB_TreePanels.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -35,14 +35,14 @@ wxFB_GridTweaks::wxFB_GridTweaks( wxWindow* parent, wxWindowID id, const wxPoint
 	wxStaticText* m_staticText341;
 	m_staticText341 = new wxStaticText( this, wxID_ANY, wxT("Percent of the square taken up by text and number:"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText341->Wrap( -1 );
-	m_staticText341->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	m_staticText341->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString ) );
 	
 	gbSizer1->Add( m_staticText341, wxGBPosition( 2, 0 ), wxGBSpan( 1, 3 ), wxALIGN_CENTER_VERTICAL, 10 );
 	
 	wxStaticText* m_staticText3411;
 	m_staticText3411 = new wxStaticText( this, wxID_ANY, wxT("Does not have to add up to 100."), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText3411->Wrap( -1 );
-	m_staticText3411->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 93, 90, false, wxEmptyString ) );
+	m_staticText3411->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_ITALIC, wxFONTWEIGHT_NORMAL, false, wxEmptyString ) );
 	
 	gbSizer1->Add( m_staticText3411, wxGBPosition( 3, 0 ), wxGBSpan( 1, 3 ), wxBOTTOM, 5 );
 	

--- a/src/dialogs/wxFB_TreePanels.fbp
+++ b/src/dialogs/wxFB_TreePanels.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -20,8 +20,10 @@
         <property name="path">.</property>
         <property name="precompiled_header"></property>
         <property name="relative_path">1</property>
+        <property name="skip_lua_events">1</property>
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
+        <property name="ui_table">UI</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
         <object class="Panel" expanded="1">
@@ -260,6 +262,7 @@
                         <event name="OnSize"></event>
                         <event name="OnSpinCtrl"></event>
                         <event name="OnSpinCtrlText"></event>
+                        <event name="OnTextEnter"></event>
                         <event name="OnUpdateUI"></event>
                     </object>
                 </object>
@@ -778,6 +781,7 @@
                         <event name="OnSize"></event>
                         <event name="OnSpinCtrl"></event>
                         <event name="OnSpinCtrlText"></event>
+                        <event name="OnTextEnter"></event>
                         <event name="OnUpdateUI"></event>
                     </object>
                 </object>
@@ -1040,6 +1044,7 @@
                         <event name="OnSize"></event>
                         <event name="OnSpinCtrl"></event>
                         <event name="OnSpinCtrlText"></event>
+                        <event name="OnTextEnter"></event>
                         <event name="OnUpdateUI"></event>
                     </object>
                 </object>

--- a/src/dialogs/wxFB_TreePanels.h
+++ b/src/dialogs/wxFB_TreePanels.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  8 2012)
+// C++ code generated with wxFormBuilder (version Oct 10 2016)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!


### PR DESCRIPTION
Built using wxFormBuilder ToT from commit
b2b66a996ad28ff8efc6852eaa14918ee8dc7a1a. This resolves compiler
warnings due to deprecated wxFont usage.