### PR TITLE
Only ignore build folders in the root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Output
-bin
-build
-lib
+/bin
+/build
+/lib


### PR DESCRIPTION
The current .gitignore ends up excluding folders like deps/luajit/lib
which should be included.