### PR TITLE
Fix crash introduced by 4d0e0d.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -413,7 +413,9 @@ XGridCtrl::OnPaint(wxPaintEvent & WXUNUSED(evt))
         if (m_rebusCtrl && ! m_rebusCtrl->IsShown())
             m_rebusCtrl->Show();
         DrawGrid(dc, GetUpdateRegion());
-        ConnectEvents();
+        if (!IsEmpty()) {
+            ConnectEvents();
+        }
     }
     else
     {


### PR DESCRIPTION
Events should only be connected when a puzzle is open. All of the
event handlers assert that this is the case.