### PR TITLE
Add -h when linking images/scripts folders.

### DIFF
--- a/src/premake4.lua
+++ b/src/premake4.lua
@@ -124,9 +124,9 @@ project "XWord"
             "cd $TARGET_BUILD_DIR",
             -- Symlink images and scripts
             "mkdir -p $PLUGINS_FOLDER_PATH",
-            "ln -sF ../../../../../scripts $PLUGINS_FOLDER_PATH/scripts",
+            "ln -sFh ../../../../../scripts $PLUGINS_FOLDER_PATH/scripts",
             "mkdir -p $UNLOCALIZED_RESOURCES_FOLDER_PATH",
-            "ln -sF ../../../../../images $UNLOCALIZED_RESOURCES_FOLDER_PATH/images",
+            "ln -sFh ../../../../../images $UNLOCALIZED_RESOURCES_FOLDER_PATH/images",
             -- Copy Info.plist and xword.icns
             "cp ../../src/Info.plist $INFOPLIST_PATH",
             "cp ../../images/xword.icns $UNLOCALIZED_RESOURCES_FOLDER_PATH",


### PR DESCRIPTION
Otherwise, if the link already exists (e.g. for builds after the first
one), an extraneous link will be created at images/images and
scripts/scripts, because the existing symlink at the destination is
followed. This resolves the issue noted in the comments of issue #5.