### PR TITLE
Fix initial source load in download plugin.

### DIFF
--- a/scripts/download/sources.lua
+++ b/scripts/download/sources.lua
@@ -470,7 +470,7 @@ function SourceList.get_default_sources()
     local sources = serialize.loadfile(path.join(xword.configdir, 'download', 'sources.lua'))
     -- Fallback on the default sources
     if not sources then
-        sources = serialize.loadfile(path.join(xword.scriptsdir, unpack(split(_R, '%.')), 'default_sources.lua'))
+        sources = serialize.loadfile(path.join(xword.scriptsdir, unpack(split(_R, '.')), 'default_sources.lua'))
     end
     return SourceList.new(sources or {})
 end


### PR DESCRIPTION
pl.stringx.split's second argument isn't actually a regular
expression, despite its name. See:

https://github.com/stevedonovan/Penlight/blob/master/lua/pl/stringx.lua#L186

as plain is set to true if the re argument is provided. The "." at the
end of the folder name was being included in the file name causing the
read to fail.