### PR TITLE
Lua plugin UI fixes.

### DIFF
--- a/scripts/download/gui/download.fbp
+++ b/scripts/download/gui/download.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration">; </property>
         <property name="code_generation">Python</property>
@@ -850,7 +850,7 @@
                                                     </object>
                                                     <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
-                                                        <property name="flag">wxEXPAND|wxALIGN_CENTER_VERTICAL|wxRIGHT|wxLEFT</property>
+                                                        <property name="flag">wxEXPAND|wxRIGHT|wxLEFT</property>
                                                         <property name="proportion">0</property>
                                                         <object class="wxBoxSizer" expanded="0">
                                                             <property name="minimum_size"></property>
@@ -3988,6 +3988,7 @@
                                         <event name="OnSize"></event>
                                         <event name="OnSpinCtrl"></event>
                                         <event name="OnSpinCtrlText"></event>
+                                        <event name="OnTextEnter"></event>
                                         <event name="OnUpdateUI"></event>
                                     </object>
                                 </object>
@@ -5036,6 +5037,7 @@
                                             <property name="minimum_size"></property>
                                             <property name="name">sbSizer1</property>
                                             <property name="orient">wxHORIZONTAL</property>
+                                            <property name="parent">1</property>
                                             <property name="permission">none</property>
                                             <event name="OnUpdateUI"></event>
                                             <object class="sizeritem" expanded="0">

--- a/scripts/download/gui/wxFB.lua
+++ b/scripts/download/gui/wxFB.lua
@@ -1,6 +1,6 @@
 -- Converted from python by py2lua
 -- python file: wxFB.py
--- modtime: 1475969737
+-- modtime: 1477178435
 -- ----------------------------------
 
 local wxfb = {} -- Table to hold classes
@@ -8,7 +8,7 @@ local wxfb = {} -- Table to hold classes
 local require_bmp = require("wx.lib.bmp") -- require function for images
 
 ---------------------------------------------------------------------------
--- Python code generated with wxFormBuilder (version Nov  6 2013)
+-- Python code generated with wxFormBuilder (version Oct 10 2016)
 -- http://www.wxformbuilder.org/
 --
 -- PLEASE DO "NOT" EDIT THIS FILE!
@@ -55,7 +55,7 @@ function wxfb.DownloadDialog(parent)
     bSizer2:Add( self.prev, 0, wx.wxALIGN_CENTER_VERTICAL, 5 )
     
     self.label = TextButton( self.panel, wx.wxID_ANY, "Label", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.label:SetFont( wx.wxFont( 12, 70, 90, 92, false, "" ) )
+    self.label:SetFont( wx.wxFont( 12, wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.label:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     self.label:SetToolTip( "Download missing puzzles" )
     
@@ -87,7 +87,7 @@ function wxfb.DownloadDialog(parent)
     local queueCountSizer = wx.wxBoxSizer( wx.wxHORIZONTAL )
     
     self.queue_count = TextButton( self.panel, wx.wxID_ANY, "0", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.queue_count:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.queue_count:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.queue_count:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     self.queue_count:SetToolTip( "Download queue" )
     
@@ -97,12 +97,12 @@ function wxfb.DownloadDialog(parent)
     queueCountSizer:Add( self.queueBmp, 0, wx.wxALIGN_CENTER_VERTICAL, 5 )
     
     
-    bSizer3:Add( queueCountSizer, 0, wx.wxEXPAND+wx.wxALIGN_CENTER_VERTICAL+wx.wxRIGHT+wx.wxLEFT, 5 )
+    bSizer3:Add( queueCountSizer, 0, wx.wxEXPAND+wx.wxRIGHT+wx.wxLEFT, 5 )
     
     local errorCountSizer = wx.wxBoxSizer( wx.wxHORIZONTAL )
     
     self.error_count = TextButton( self.panel, wx.wxID_ANY, "0", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.error_count:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.error_count:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.error_count:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     self.error_count:SetToolTip( "Download missing puzzles" )
     
@@ -186,7 +186,7 @@ function wxfb.DownloadHeading(parent)
     bSizer8:Add( self.expand_button, 0, wx.wxALIGN_CENTER_VERTICAL+wx.wxRIGHT, 5 )
     
     self.label = TextButton( self.m_panel4, wx.wxID_ANY, "Source", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.label:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.label:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     
     bSizer8:Add( self.label, 1, wx.wxALIGN_CENTER_VERTICAL+wx.wxRIGHT, 5 )
     
@@ -243,19 +243,19 @@ function wxfb.DownloadList(parent)
     bSizer13:Add(0, 0, 1)
     
     self.erase_history = TextButton( self, wx.wxID_ANY, "Clear History", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.erase_history:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.erase_history:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.erase_history:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     
     bSizer13:Add( self.erase_history, 0, wx.wxALL, 5 )
     
     self.cancel_downloads = TextButton( self, wx.wxID_ANY, "Cancel Downloads", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.cancel_downloads:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.cancel_downloads:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.cancel_downloads:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     
     bSizer13:Add( self.cancel_downloads, 0, wx.wxALL, 5 )
     
     self.close = TextButton( self, wx.wxID_ANY, "X", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
-    self.close:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.close:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.close:SetForegroundColour( wx.wxColour( 0, 0, 255 ) )
     self.close:SetToolTip( "Close" )
     
@@ -520,25 +520,25 @@ function wxfb.PuzzleSourceDialog(parent)
     
     local sbSizer1 = wx.wxStaticBoxSizer( wx.wxStaticBox( self.m_panel3, wx.wxID_ANY, "Days available" ), wx.wxHORIZONTAL )
     
-    self.day1 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Mon", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day1 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Mon", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day1, 0, wx.wxALL, 5 )
     
-    self.day2 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Tue", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day2 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Tue", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day2, 0, wx.wxALL, 5 )
     
-    self.day3 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Wed", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day3 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Wed", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day3, 0, wx.wxALL, 5 )
     
-    self.day4 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Thu", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day4 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Thu", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day4, 0, wx.wxALL, 5 )
     
-    self.day5 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Fri", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day5 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Fri", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day5, 0, wx.wxALL, 5 )
     
-    self.day6 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Sat", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day6 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Sat", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day6, 0, wx.wxALL, 5 )
     
-    self.day7 = wx.wxCheckBox( self.m_panel3, wx.wxID_ANY, "Sun", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
+    self.day7 = wx.wxCheckBox( sbSizer1:GetStaticBox(), wx.wxID_ANY, "Sun", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     sbSizer1:Add( self.day7, 0, wx.wxALL, 5 )
     
     
@@ -546,7 +546,7 @@ function wxfb.PuzzleSourceDialog(parent)
     
     self.m_staticText122 = wx.wxStaticText( self.m_panel3, wx.wxID_ANY, "Date format codes for puzzle URL and filename:", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     self.m_staticText122:Wrap( -1 )
-    self.m_staticText122:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 90, false, "" ) )
+    self.m_staticText122:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_NORMAL, false, "" ) )
     
     bSizer26:Add( self.m_staticText122, 0, wx.wxTOP+wx.wxRIGHT+wx.wxLEFT, 5 )
     
@@ -624,7 +624,7 @@ function wxfb.PuzzleSourceDialog(parent)
     
     self.m_staticText37 = wx.wxStaticText( self.m_panel4, wx.wxID_ANY, "Note: Authentication may not work for every source.  Login is attempted via an HTML form.  Any cookies set after a successful login are saved and used to download puzzles.", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     self.m_staticText37:Wrap( 325 )
-    self.m_staticText37:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 93, 90, false, "" ) )
+    self.m_staticText37:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_ITALIC, wx.wxFONTWEIGHT_NORMAL, false, "" ) )
     
     bSizer29:Add( self.m_staticText37, 0, wx.wxALL+wx.wxALIGN_CENTER_HORIZONTAL, 5 )
     
@@ -641,7 +641,7 @@ function wxfb.PuzzleSourceDialog(parent)
     
     self.custom_func_message = wx.wxStaticText( self.m_panel6, wx.wxID_ANY, "This source uses a custom download function!  Not all changes you make in this dialog may have the desired effect.  Click to view the function.", wx.wxDefaultPosition, wx.wxDefaultSize, wx.wxALIGN_CENTRE )
     self.custom_func_message:Wrap( 250 )
-    self.custom_func_message:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.custom_func_message:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     self.custom_func_message:SetBackgroundColour( wx.wxColour( 255, 255, 0 ) )
     self.custom_func_message:Hide()
     
@@ -669,7 +669,7 @@ function wxfb.PuzzleSourceDialog(parent)
     
     self.m_staticText21 = wx.wxStaticText( self.custom_func_panel, wx.wxID_ANY, "Don't edit this function unless you know what you're doing.", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     self.m_staticText21:Wrap( -1 )
-    self.m_staticText21:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 70, 90, 92, false, "" ) )
+    self.m_staticText21:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_DEFAULT, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_BOLD, false, "" ) )
     
     bSizer34:Add( self.m_staticText21, 0, wx.wxALL, 5 )
     
@@ -678,13 +678,13 @@ function wxfb.PuzzleSourceDialog(parent)
     
     self.m_staticText40 = wx.wxStaticText( self.m_panel8, wx.wxID_ANY, "function(puzzle)", wx.wxDefaultPosition, wx.wxDefaultSize, 0 )
     self.m_staticText40:Wrap( -1 )
-    self.m_staticText40:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 76, 90, 90, false, "" ) )
+    self.m_staticText40:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_TELETYPE, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_NORMAL, false, "" ) )
     self.m_staticText40:SetForegroundColour( wx.wxSystemSettings.GetColour( wx.wxSYS_COLOUR_GRAYTEXT ) )
     
     bSizer32:Add( self.m_staticText40, 0, wx.wxEXPAND, 5 )
     
     self.func = wx.wxTextCtrl( self.m_panel8, wx.wxID_ANY, "", wx.wxDefaultPosition, wx.wxDefaultSize, wx.wxTE_DONTWRAP+wx.wxTE_MULTILINE+wx.wxNO_BORDER )
-    self.func:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), 76, 90, 90, false, "" ) )
+    self.func:SetFont( wx.wxFont( wx.wxNORMAL_FONT:GetPointSize(), wx.wxFONTFAMILY_TELETYPE, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_NORMAL, false, "" ) )
     
     bSizer32:Add( self.func, 1, wx.wxEXPAND, 5 )
     

--- a/scripts/download/gui/wxFB.py
+++ b/scripts/download/gui/wxFB.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*- 
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version Nov  6 2013)
+## Python code generated with wxFormBuilder (version Oct 10 2016)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO "NOT" EDIT THIS FILE!
@@ -51,7 +51,7 @@ class DownloadDialog ( wx.Dialog ):
 		bSizer2.Add( self.prev, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 		
 		self.label = TextButton( self.panel, wx.ID_ANY, u"Label", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.label.SetFont( wx.Font( 12, 70, 90, 92, False, wx.EmptyString ) )
+		self.label.SetFont( wx.Font( 12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.label.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		self.label.SetToolTipString( u"Download missing puzzles" )
 		
@@ -83,7 +83,7 @@ class DownloadDialog ( wx.Dialog ):
 		queueCountSizer = wx.BoxSizer( wx.HORIZONTAL )
 		
 		self.queue_count = TextButton( self.panel, wx.ID_ANY, u"0", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.queue_count.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.queue_count.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.queue_count.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		self.queue_count.SetToolTipString( u"Download queue" )
 		
@@ -93,12 +93,12 @@ class DownloadDialog ( wx.Dialog ):
 		queueCountSizer.Add( self.queueBmp, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 		
 		
-		bSizer3.Add( queueCountSizer, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
+		bSizer3.Add( queueCountSizer, 0, wx.EXPAND|wx.RIGHT|wx.LEFT, 5 )
 		
 		errorCountSizer = wx.BoxSizer( wx.HORIZONTAL )
 		
 		self.error_count = TextButton( self.panel, wx.ID_ANY, u"0", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.error_count.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.error_count.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.error_count.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		self.error_count.SetToolTipString( u"Download missing puzzles" )
 		
@@ -220,7 +220,7 @@ class DownloadHeading ( wx.Panel ):
 		bSizer8.Add( self.expand_button, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 5 )
 		
 		self.label = TextButton( self.m_panel4, wx.ID_ANY, u"Source", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.label.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.label.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		
 		bSizer8.Add( self.label, 1, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 5 )
 		
@@ -290,19 +290,19 @@ class DownloadList ( wx.Panel ):
 		bSizer13.AddSpacer( ( 0, 0), 1, wx.EXPAND, 5 )
 		
 		self.erase_history = TextButton( self, wx.ID_ANY, u"Clear History", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.erase_history.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.erase_history.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.erase_history.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		
 		bSizer13.Add( self.erase_history, 0, wx.ALL, 5 )
 		
 		self.cancel_downloads = TextButton( self, wx.ID_ANY, u"Cancel Downloads", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.cancel_downloads.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.cancel_downloads.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.cancel_downloads.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		
 		bSizer13.Add( self.cancel_downloads, 0, wx.ALL, 5 )
 		
 		self.close = TextButton( self, wx.ID_ANY, u"X", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.close.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.close.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.close.SetForegroundColour( wx.Colour( 0, 0, 255 ) )
 		self.close.SetToolTipString( u"Close" )
 		
@@ -610,25 +610,25 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		sbSizer1 = wx.StaticBoxSizer( wx.StaticBox( self.m_panel3, wx.ID_ANY, u"Days available" ), wx.HORIZONTAL )
 		
-		self.day1 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Mon", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day1 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Mon", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day1, 0, wx.ALL, 5 )
 		
-		self.day2 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Tue", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day2 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Tue", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day2, 0, wx.ALL, 5 )
 		
-		self.day3 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Wed", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day3 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Wed", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day3, 0, wx.ALL, 5 )
 		
-		self.day4 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Thu", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day4 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Thu", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day4, 0, wx.ALL, 5 )
 		
-		self.day5 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Fri", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day5 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Fri", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day5, 0, wx.ALL, 5 )
 		
-		self.day6 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Sat", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day6 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Sat", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day6, 0, wx.ALL, 5 )
 		
-		self.day7 = wx.CheckBox( self.m_panel3, wx.ID_ANY, u"Sun", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.day7 = wx.CheckBox( sbSizer1.GetStaticBox(), wx.ID_ANY, u"Sun", wx.DefaultPosition, wx.DefaultSize, 0 )
 		sbSizer1.Add( self.day7, 0, wx.ALL, 5 )
 		
 		
@@ -636,7 +636,7 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		self.m_staticText122 = wx.StaticText( self.m_panel3, wx.ID_ANY, u"Date format codes for puzzle URL and filename:", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText122.Wrap( -1 )
-		self.m_staticText122.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 90, False, wx.EmptyString ) )
+		self.m_staticText122.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, wx.EmptyString ) )
 		
 		bSizer26.Add( self.m_staticText122, 0, wx.TOP|wx.RIGHT|wx.LEFT, 5 )
 		
@@ -714,7 +714,7 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		self.m_staticText37 = wx.StaticText( self.m_panel4, wx.ID_ANY, u"Note: Authentication may not work for every source.  Login is attempted via an HTML form.  Any cookies set after a successful login are saved and used to download puzzles.", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText37.Wrap( 325 )
-		self.m_staticText37.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 93, 90, False, wx.EmptyString ) )
+		self.m_staticText37.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_ITALIC, wx.FONTWEIGHT_NORMAL, False, wx.EmptyString ) )
 		
 		bSizer29.Add( self.m_staticText37, 0, wx.ALL|wx.ALIGN_CENTER_HORIZONTAL, 5 )
 		
@@ -731,7 +731,7 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		self.custom_func_message = wx.StaticText( self.m_panel6, wx.ID_ANY, u"This source uses a custom download function!  Not all changes you make in this dialog may have the desired effect.  Click to view the function.", wx.DefaultPosition, wx.DefaultSize, wx.ALIGN_CENTRE )
 		self.custom_func_message.Wrap( 250 )
-		self.custom_func_message.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.custom_func_message.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		self.custom_func_message.SetBackgroundColour( wx.Colour( 255, 255, 0 ) )
 		self.custom_func_message.Hide()
 		
@@ -759,7 +759,7 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		self.m_staticText21 = wx.StaticText( self.custom_func_panel, wx.ID_ANY, u"Don't edit this function unless you know what you're doing.", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText21.Wrap( -1 )
-		self.m_staticText21.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 70, 90, 92, False, wx.EmptyString ) )
+		self.m_staticText21.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, wx.EmptyString ) )
 		
 		bSizer34.Add( self.m_staticText21, 0, wx.ALL, 5 )
 		
@@ -768,13 +768,13 @@ class PuzzleSourceDialog ( wx.Dialog ):
 		
 		self.m_staticText40 = wx.StaticText( self.m_panel8, wx.ID_ANY, u"function(puzzle)", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText40.Wrap( -1 )
-		self.m_staticText40.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 76, 90, 90, False, wx.EmptyString ) )
+		self.m_staticText40.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_TELETYPE, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, wx.EmptyString ) )
 		self.m_staticText40.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_GRAYTEXT ) )
 		
 		bSizer32.Add( self.m_staticText40, 0, wx.EXPAND, 5 )
 		
 		self.func = wx.TextCtrl( self.m_panel8, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_DONTWRAP|wx.TE_MULTILINE|wx.NO_BORDER )
-		self.func.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), 76, 90, 90, False, wx.EmptyString ) )
+		self.func.SetFont( wx.Font( wx.NORMAL_FONT.GetPointSize(), wx.FONTFAMILY_TELETYPE, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, wx.EmptyString ) )
 		
 		bSizer32.Add( self.func, 1, wx.EXPAND, 5 )
 		

--- a/scripts/download/manager.lua
+++ b/scripts/download/manager.lua
@@ -112,7 +112,7 @@ M:connect{
                 wx.wxDefaultPosition, wx.wxDefaultSize, flags)
             values[label] = ctrl
             ctrl:SetMinSize(wx.wxSize(200, -1))
-            sizer:Add(ctrl, 1, wx.wxALIGN_CENTER_VERTICAL + wx.wxEXPAND)
+            sizer:Add(ctrl, 1, wx.wxEXPAND)
         end
         -- Prompt
         dlg:Fit()

--- a/scripts/xworddebug/py2lua.lua
+++ b/scripts/xworddebug/py2lua.lua
@@ -64,6 +64,9 @@ local function convert(filename, writefile, luafile)
     local f = assert(io.open(filename, 'r'))
     local text = f:read('*a')
     f:close()
+    
+    -- Use unix newlines
+    text = text:gsub('\r\n', '\n')
 
     -- Remove coding
     text = text:gsub('#.-coding:.-\n', '\n')
@@ -315,8 +318,8 @@ local function is_modified(luafile)
     local f = io.open(luafile, 'r')
     if f then
         f:read("*line") -- py2lua line
-        local pyfile = f:read("*line"):match("--.*:%s+(.*)") -- python file
-        local mtime = tonumber(f:read("*line"):match("--.*:%s+(.*)")) -- modified time
+        local pyfile = f:read("*line"):match("--.*:%s+(.*%.py)") -- python file
+        local mtime = tonumber(f:read("*line"):match("--.*:%s+(%d*)")) -- modified time
         f:close()
         if pyfile and mtime then
             -- Get the full path of the python file

--- a/scripts/xworddebug/py2lua.lua
+++ b/scripts/xworddebug/py2lua.lua
@@ -216,7 +216,7 @@ local function convert(filename, writefile, luafile)
         if not luafile then
             luafile = filename:gsub('%.py', '%.lua')
         end
-        f = io.open(luafile, 'w')
+        f = io.open(luafile, 'wb')
         -- Keep track of filename and modification time
         f:write(([[
 -- Converted from python by py2lua

--- a/scripts/xworddebug/wxFB.fbp
+++ b/scripts/xworddebug/wxFB.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="11" />
+    <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">Python</property>

--- a/scripts/xworddebug/wxFB.lua
+++ b/scripts/xworddebug/wxFB.lua
@@ -1,12 +1,12 @@
 -- Converted from python by py2lua
 -- python file: wxFB.py
--- modtime: 1475969738
+-- modtime: 1477182147
 -- ----------------------------------
 
 local wxfb = {} -- Table to hold classes
 
 ---------------------------------------------------------------------------
--- Python code generated with wxFormBuilder (version Nov  6 2013)
+-- Python code generated with wxFormBuilder (version Oct 10 2016)
 -- http://www.wxformbuilder.org/
 --
 -- PLEASE DO "NOT" EDIT THIS FILE!
@@ -28,7 +28,7 @@ function wxfb.DebugDialog(parent)
     local bSizer2 = wx.wxBoxSizer( wx.wxVERTICAL )
     
     self.text = wx.wxTextCtrl( self.panel, wx.wxID_ANY, "", wx.wxDefaultPosition, wx.wxDefaultSize, wx.wxHSCROLL+wx.wxTE_MULTILINE )
-    self.text:SetFont( wx.wxFont( 8, 75, 90, 90, false, "Consolas" ) )
+    self.text:SetFont( wx.wxFont( 8, wx.wxFONTFAMILY_MODERN, wx.wxFONTSTYLE_NORMAL, wx.wxFONTWEIGHT_NORMAL, false, "Consolas" ) )
     
     bSizer2:Add( self.text, 1, wx.wxALL+wx.wxEXPAND, 5 )
     

--- a/scripts/xworddebug/wxFB.py
+++ b/scripts/xworddebug/wxFB.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*- 
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version Nov  6 2013)
+## Python code generated with wxFormBuilder (version Oct 10 2016)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO "NOT" EDIT THIS FILE!
@@ -27,7 +27,7 @@ class DebugDialog ( wx.Frame ):
 		bSizer2 = wx.BoxSizer( wx.VERTICAL )
 		
 		self.text = wx.TextCtrl( self.panel, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.HSCROLL|wx.TE_MULTILINE )
-		self.text.SetFont( wx.Font( 8, 75, 90, 90, False, "Consolas" ) )
+		self.text.SetFont( wx.Font( 8, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Consolas" ) )
 		
 		bSizer2.Add( self.text, 1, wx.ALL|wx.EXPAND, 5 )
 		


### PR DESCRIPTION
-Fix assert error with wxEXPAND|wxALIGN_CENTER_VERTICAL.
-Regegenerate wxFormBuilder and wxFB.lua files.
-Convert Windows to Linux line endings in py2lua.lua. Windows line
endings break the Lua interpreter on Mac (at least) with the newly
regenerated .lua files.
-Handle Window line endings when reading the last modified time from
the generated .lua files.