### PR TITLE
Properly close Lua plugin dialogs.

### DIFF
--- a/scripts/download/init.lua
+++ b/scripts/download/init.lua
@@ -59,10 +59,6 @@ if not xword.frame then
     local config = require(_R .. 'config')
     config.load()
     local dlg = show_dialog()
-    dlg:Connect(wx.wxEVT_CLOSE_WINDOW, function (evt)
-        dlg:Destroy()
-        evt:Skip()
-    end)
 end
 
 return { init, uninit }

--- a/scripts/graph/dialog.lua
+++ b/scripts/graph/dialog.lua
@@ -86,11 +86,6 @@ local function ShowDialog(points)
     dlg:Fit()
     dlg:SetMinSize(dlg:GetSize())
 
-    dlg:Connect(wx.wxEVT_CLOSE_WINDOW, function(evt)
-        dlg:Destroy()
-        evt:Skip()
-    end)
-
     dlg:Fit()
     dlg:Center()
     dlg:ShowModal()

--- a/scripts/xword/pkgmgr/dialog.lua
+++ b/scripts/xword/pkgmgr/dialog.lua
@@ -596,7 +596,7 @@ function P.PackageDialog(opts)
     end
 
     dlg:Connect(wx.wxEVT_CLOSE_WINDOW, function(evt)
-        evt:Skip()
+        dlg:EndModal(wx.wxID_OK)
         dlg:Destroy()
         P.dlg = nil
     end)


### PR DESCRIPTION
While a modal dialog is open, menu and toolbar items are disabled.
This is undone when the dialog is dismissed. However, directly calling
Destroy() on the dialog skips resetting the state, which permanently
wedges the UI.