### PR TITLE
Use cross-platform API to show Lua errors.

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -230,7 +230,7 @@ int MyApp::OnExit()
         if (m_luaMessages) {
             XWordErrorMessage(NULL, _T("Errors occurred.  See log file: %s"), (const wxChar *)GetLuaLogFilename().c_str());
         #ifdef __WXDEBUG__
-            wxShell(wxString::Format(_T("\"%s\""), (const wxChar *)GetLuaLogFilename().c_str()));
+            wxLaunchDefaultApplication(GetLuaLogFilename());
         #endif // __WXDEBUG__
         }
         delete m_luaLog;


### PR DESCRIPTION
For debug builds, if any Lua errors occur, we try to show the log file
when the app is closed. However, this is done by trying to execute the
file directly, which doesn't work on Mac/Linux. Instead, use a
cross-platform wxWidgets API to open the file in the default handler.