### PR TITLE
Configure Travis and AppVeyor builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: cpp
+os: osx
+
+env:
+  matrix:
+    - CONFIGURATION="Debug"
+    - CONFIGURATION="Release"
+
+# Build and install wxWidgets, with our custom tweaks patch
+install:
+  - ./build-wxwidgets.sh $CONFIGURATION
+
+# Cache the compiled wxWidgets so it can be in with future builds
+cache:
+  directories:
+    - $HOME/wxWidgets
+
+# Run premake4 to create the Xcode project
+before_script:
+  - ./premake4 --wx-config-debug=$HOME/wxWidgets/bin/wx-config --wx-config-release=$HOME/wxWidgets/bin/wx-config xcode4
+
+# Build XWord
+script:
+  - xcodebuild -project build/xcode4/XWord.xcodeproj -configuration $CONFIGURATION build
+
+# For deployed builds, zip the .app folder
+before_deploy:
+  - pushd bin/$CONFIGURATION
+  - zip -r XWord-macOS.zip XWord.app/ -x *.fbp
+  - popd
+
+# Deploy tagged release builds to GitHub Releases
+deploy:
+  provider: releases
+  api_key:
+    secure: dT5W1MsTMFYjN6mDnSqpL7QjHkL/R6When5elNX9dwGLafCyRN2ohAUa6lpt17v8NG3//qF9BZLZOymA7D9kNqILGbt8mjCu053WBknekI9BTG593HQhsV2y0nA8p2J3y95/Qdty/t0jg/QdWqV60O0w6VQFGoHOb9EUVKCu9cR+WX4kVz2uadB8ms8r2YDeC0fUnrA/w1XnopohJw3P/hiV6S2+u1eeWFFyjOTuTJcyg6cHkxMysj/4N4llxOU/to0/nQYKg+sc9B7hHLFmwHxLbq1prn9LG9kRwDmCnzNlV0OgPOT2vP+LSwyfvp4zuHNC61sIH8OSVKCmn3keM/ZDahKB37Zd0eQKBxLNm9iu/UibBN7R+4QtVXgPkfqZb9bFhpy9fi+MxiYXUzbl3q3p7werLooI42KFzkJ2KxSkP3ZEQko3XsdAdgeBZVXzD/Ze0IMnaTQSeCPQbzbMjXA0mIwOkWCIj77dqOnQOdjAURA+U5tUt1Q2TUa9yJHXT5O6J2XNXdCbM5JlzBNoo9orcTjuwnsyplvMovKw1Qx0DGVG0hNakp2tNszsH4LeJKrAdWr1KXGu392Shq3XCya3X76jhQBO9zMDAe0txdFpnmx6Pi8GYlFabU2OWoWmNsnJVxOsMGKL8wz1vRx4uakFY4WzgDO/SI/6zkQ43W8=
+  file: bin/$CONFIGURATION/XWord-macOS.zip
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $CONFIGURATION = "Release"

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ Windows builds include dlls for everything except wxWidgets.
 A debug build of wxWidgets is needed for debug builds of XWord, and likewise for release builds. The
 following configure options should work as a baseline for release builds:
 
-    $ ./configure --enable-unicode --disable-shared --enable-compat28
+    $ ./configure --disable-shared --enable-compat28
 
 For debug builds, add --enable-debug. For Mac OS builds, add --enable-universal-binary=i386
---with-macosx-version-min=10.6. You may also want to add -fvisibility-inlines-hidden to CFLAGS, 
-CXXFLAGS, CPPFLAGS, OBJCFLAGS, and OBJCXXFLAGS, as this is the default option used by the Mac 
+--with-macosx-version-min=10.6. You may also want to add -fvisibility-inlines-hidden to CFLAGS,
+CXXFLAGS, CPPFLAGS, OBJCFLAGS, and OBJCXXFLAGS, as this is the default option used by the Mac
 toolchain, and this option should be used consistently across an app and all of its dependencies.
 
 ### Lua libraries ###

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+version: '{build}'
+test: off
+
+configuration:
+  - Debug
+  - Release
+
+# Build and install wxWidgets, with our custom tweaks patch
+install:
+  - call "%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
+  - bash build-wxwidgets.sh %CONFIGURATION%
+
+# Cache the compiled wxWidgets so it can be in with future builds
+cache:
+  - '%USERPROFILE%\wxWidgets'
+
+# Run premake4 to create the Visual Studio project
+before_build:
+  - premake4.exe --wx-prefix="%USERPROFILE%/wxWidgets" vs2010
+
+# Build XWord
+build_script:
+  - msbuild build/vs2010/XWord.sln /p:Configuration=%CONFIGURATION%
+
+# For deployed builds, zip the build folder
+after_build:
+  - 7z a bin\%CONFIGURATION%\XWord-Windows.zip "%APPVEYOR_BUILD_FOLDER%\bin\%CONFIGURATION%\*" -r -x!*.exp -x!*.lib -x!*.pdb -x!*.idb -x!*.ilk -x!*.fbp
+
+artifacts:
+  path: bin\%CONFIGURATION%\XWord-Windows.zip
+  name: XWord-Windows.zip
+
+# Deploy tagged release builds to GitHub Releases
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: di7vtZSm1K8JwmYD0z+PVfcDGav/KwuK4CeBdp4oKoT7ImfJ7ksFSV6zcLcW6qui
+  artifact: XWord-Windows.zip
+  on:
+    appveyor_repo_tag: true
+    configuration: Release

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Script to build and install wxWidgets, with our custom tweaks patch.
+
+set -e
+
+CONFIGURATION=$1
+
+INSTALL_PATH="$HOME/wxWidgets"
+mkdir -p $INSTALL_PATH
+
+WX_CONFIGURE_FLAGS="\
+  --disable-shared \
+  --enable-compat28 \
+  --enable-universal-binary=i386 \
+  --with-macosx-version-min=10.6 \
+  CFLAGS=-fvisibility-inlines-hidden \
+  CXXFLAGS=-fvisibility-inlines-hidden \
+  CPPFLAGS=-fvisibility-inlines-hidden \
+  OBJCFLAGS=-fvisibility-inlines-hidden \
+  OBJCXXFLAGS=-fvisibility-inlines-hidden"
+WX_MAKE_FLAGS="SHARED=0"
+
+if [ "$CONFIGURATION" = "Debug" ]; then
+  WX_CONFIGURE_FLAGS="$WX_CONFIGURE_FLAGS --enable-debug"
+  WX_MAKE_FLAGS="$WX_MAKE_FLAGS BUILD=debug"
+elif [ "$CONFIGURATION" = "Release" ]; then
+  WX_MAKE_FLAGS="$WX_MAKE_FLAGS BUILD=release"
+else
+  echo "Unsupported configuration: $CONFIGURATION"
+  echo "Please use one of Debug or Release"
+  exit 1
+fi
+echo "Building wxWidgets for configuration: $CONFIGURATION"
+
+if [ "$OSTYPE" = "darwin"* ]; then
+  # Mac OS X
+  BUILD_COMMAND="./configure --prefix=$INSTALL_PATH $WX_CONFIGURE_FLAGS && make && make install"
+else
+  # Windows
+  BUILD_COMMAND="sed -e 's/WXWIN_COMPATIBILITY_2_8 0/WXWIN_COMPATIBILITY_2_8 1/' -i include/wx/msw/setup.h"
+  BUILD_COMMAND="$BUILD_COMMAND && cd build/msw && nmake.exe -f makefile.vc $WX_MAKE_FLAGS"
+  BUILD_COMMAND="$BUILD_COMMAND && cp -a ../../lib ../../include $INSTALL_PATH"
+fi
+
+# Check to see if the cache directory is empty
+if [ ! -d "$INSTALL_PATH/lib" ]; then
+  curl -fsSL -o wxWidgets-3.1.0.tar.bz2 https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2
+  tar -xjf wxWidgets-3.1.0.tar.bz2
+  cd wxWidgets-3.1.0
+  patch -p1 -i ../wxaui-tweaks.patch
+  eval $BUILD_COMMAND
+else
+  echo "Using cached directory."
+fi


### PR DESCRIPTION
This is a start towards resolving Issue #40. These configs build the
debug and release builds of XWord on Mac and Windows. If a new release
is created on GitHub, a release build will be zipped up and posted as
part of the release.

The --enable-unicode reference in README.md is removed, as this is the
default as of wxWidgets 2.9.
