### PR TITLE
Fix crash on XWord close.

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -248,15 +248,21 @@ int MyApp::OnExit()
     wxFileOutputStream fileStream(configFile.GetFullPath());
     config->Save(fileStream);
 
-    delete m_frame;
-
-    delete m_config;
-
     // Clean up printing stuff.
     delete g_printData;
     delete g_pageSetupData;
 
     return wxApp::OnExit();
+}
+
+void MyApp::CleanUp() {
+    wxApp::CleanUp();
+
+    // We can't safely delete the ConfigManager in OnExit because it has a correctness check
+    // ensuring that all registered callbacks are unregistered, but OnExit is called prior to
+    // wxWidgets cleanup (which means, in particular, that MyFrame may not yet be destroyed). So we
+    // delete it after the cleanup instead.
+    delete m_config;
 }
 
 //------------------------------------------------------------------------------

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -248,6 +248,8 @@ int MyApp::OnExit()
     wxFileOutputStream fileStream(configFile.GetFullPath());
     config->Save(fileStream);
 
+    delete m_frame;
+
     delete m_config;
 
     // Clean up printing stuff.

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -59,6 +59,7 @@ class MyApp : public wxApp
 public:
     bool OnInit();
     int OnExit();
+    void CleanUp();
 
     ConfigManager & GetConfigManager() { return *m_config; }
     bool IsPortable() { return m_isPortable; }


### PR DESCRIPTION
Since MyApp creates a new MyFrame object in OnInit, it should delete
that object in OnExit prior to deleting its ConfigManager instance.
Otherwise, MyFrame may still hold a registered callback in
ConfigManager, triggering a wxASSERT failure when ConfigManager's
destructor is called first.

Fixes #45