### PR TITLE
Clean up Windows hack in paths.cpp.

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -81,6 +81,8 @@ bool MyApp::OnInit()
     wxCmdLineParser cmd(cmdLineDesc, argc, argv);
     cmd.Parse(false); // don't show usage
 
+    InitPaths();
+
     // Portable mode is enabled if there is a file named
     // "portable_mode_enabled" in the executable directory or with the
     // command line switch -p

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -56,34 +56,6 @@ wxString GetConfigFile()
     return GetConfigDir() + sep() + configFileName;
 }
 
-// If wxWidgets is compiled in debug mode under windows, *and* the exe is located
-// in a folder that begins with "debug" certain wxStandardPaths functions return
-// the parent directory instead of the exe directory.  This is clearly intended
-// as a feature, but I find it to be a pain.
-// The following are affected:
-//     wxStandardPaths::GetDataDir
-//     wxStandardPaths::GetPluginsDir
-//     wxStandardPaths::GetResourcesDir
-//     wxStandardPaths::GetAppDir
-// Fortunately these should always return the exe directory.
-// TODO: Investigate using wxStandardPaths::DontIgnoreAppSubDir with wxWidgets 2.9.1+
-#if defined(_DEBUG) && defined(__WXMSW__)
-
-wxString GetImagesDir()
-{
-    return exedir() + sep() + _T("images");
-}
-
-
-wxString GetScriptsDir()
-{
-    return exedir() + sep() + _T("scripts");
-}
-
-#define GetPluginsDir() exedir()
-
-#else
-
 wxString GetImagesDir()
 {
     if (wxGetApp().IsPortable())
@@ -102,9 +74,6 @@ wxString GetScriptsDir()
 }
 
 #define GetPluginsDir() wxStandardPaths::Get().GetPluginsDir()
-
-#endif // _DEBUG && __WXMSW__
-
 
 wxImage LoadXWordImage(const wxString & name, int size)
 {

--- a/src/paths.hpp
+++ b/src/paths.hpp
@@ -22,6 +22,15 @@
 #include <wx/image.h>
 #include <wx/bitmap.h>
 
+// On Windows, turn off the wxWidgets default behavior of returning the parent directory instead of
+// the exe directory when we're compiled in debug mode and the exe is located in a folder that
+// begins with "debug".
+#ifdef __WXMSW__
+#define InitPaths() wxStandardPaths::Get().DontIgnoreAppSubDir();
+#else // ! __WXMSW__
+#define InitPaths()
+#endif // __WXMSW__ / ! __WXMSW__
+
 // Locations where the application expects to find its files.
 // It is up to the caller to determine whether or not the path exists.
 wxString GetUserDataDir(); // Directory for user data


### PR DESCRIPTION
Instead of working around the Windows-specific behavior of using the
parent directory of the .exe instead of the directory containing the
.exe itself when the .exe directory contains "debug", we can turn off
this behavior by calling DontIgnoreAppSubDir().

An alternative would be to force on portable mode for debug builds,
but this has other side effects which may not be desirable, e.g.
using a different config/settings from the release build.

Fixes #41