### PR TITLE
Fix two-finger scrolling in modals on Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ follows the normal rules of numbering a grid.
 # Building XWord #
 
 XWord uses the [wxWidgets](http://www.wxwidgets.org) cross-platform toolkit
-(statically linked). wxaui-tweaks.patch slightly alters aui/framemanager. If
-you would like to use this patch, apply it to the wxWidgets directory.
+(statically linked). wxaui-tweaks.patch slightly alters aui/framemanager.
+wxwidgets-smooth-scroll-modals.patch fixes two-finger scrolling in modal
+dialogs on macOS. If you would like to use these patches, apply them to the
+wxWidgets directory.
 
 XWord uses [premake](http://industriousone.com/premake/download) to generate
 project files.  Version 4 has been used successfully, but the 5 beta may also work.

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -48,6 +48,7 @@ if [ ! -d "$INSTALL_PATH/lib" ]; then
   tar -xjf wxWidgets-3.1.0.tar.bz2
   cd wxWidgets-3.1.0
   patch -p1 -i ../wxaui-tweaks.patch
+  patch -p1 -i ../wxwidgets-smooth-scroll-modals.patch
   eval $BUILD_COMMAND
 else
   echo "Using cached directory."

--- a/wxwidgets-smooth-scroll-modals.patch
+++ b/wxwidgets-smooth-scroll-modals.patch
@@ -1,0 +1,31 @@
+From d93c0c3c571c02ee5205140354d38a85402e86ea Mon Sep 17 00:00:00 2001
+From: Jeff Davidson <jpd@google.com>
+Date: Sat, 31 Dec 2016 16:43:05 -0800
+Subject: [PATCH] Fix event dispatching in Mac modal event loops.
+
+See: http://trac.wxwidgets.org/ticket/17737
+---
+ src/osx/cocoa/evtloop.mm | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/osx/cocoa/evtloop.mm b/src/osx/cocoa/evtloop.mm
+index cf9f46e..976a973 100644
+--- a/src/osx/cocoa/evtloop.mm
++++ b/src/osx/cocoa/evtloop.mm
+@@ -216,9 +216,12 @@ static NSUInteger CalculateNSEventMaskFromEventCategory(wxEventCategory cat)
+         {
+             case NSRunContinuesResponse:
+             {
++                [[NSRunLoop currentRunLoop]
++                        runMode:NSDefaultRunLoopMode
++                        beforeDate:[NSDate dateWithTimeIntervalSinceNow: timeout/1000.0]];
+                 if ( [[NSApplication sharedApplication]
+                         nextEventMatchingMask: NSAnyEventMask
+-                        untilDate: [NSDate dateWithTimeIntervalSinceNow: timeout/1000.0]
++                        untilDate: nil
+                         inMode: NSDefaultRunLoopMode
+                         dequeue: NO] != nil )
+                     return 1;
+-- 
+2.10.1 (Apple Git-78)
+


### PR DESCRIPTION
This appears to be a bug in wxWidgets
(http://trac.wxwidgets.org/ticket/17737). The patch has been discussed
with the wxWidgets maintainers who are open to it with further
testing. It appears to resolve the issue with all of the modal dialogs
in XWord without introducing noticable regressions.

In the future, we should be able to remove this upon upgrading to the
next release of wxWidgets which includes this fix (if/when accepted).

Note that the build caches in Travis/Appveyor must be manually cleared
before this change is merged, as otherwise the cached, compiled
version of wxWidgets from prior builds will be used.

Fixes #27