### PR TITLE
Fix parsing of TXT format puzzles.

### DIFF
--- a/puz/formats/txt/load_txt.cpp
+++ b/puz/formats/txt/load_txt.cpp
@@ -167,9 +167,8 @@ void LoadTxt(Puzzle * puz, const std::string & filename, void * /* dummy */)
     for (line = f.ReadLine(); line != "<NOTEPAD>" && ! line.empty(); line = f.ReadLine())
         down.push_back(Clue(puzT(""), TrimWhitespace(decode_utf8(line))));
 
-    puz->NumberGrid();
     puz->NumberClues();
-    puz->GenerateWords();
+    puz->NumberGrid();
 
     // The rest of the puzzle is notepad
     if (line == "<NOTEPAD>")


### PR DESCRIPTION
NumberGrid() can't be called before NumberClues(), as NumberGrid()
calls GenerateWords() which expects the clues to have been numbered.
There is also an extraneous call to GenerateWords() which can be
removed.