### PR TITLE
Pin to previous OS X image to fix Mac builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 os: osx
+osx_image: xcode7.3
 
 env:
   matrix:


### PR DESCRIPTION
Newer OS X versions require either wxWidgets 3.1.1 (which is
backwards-incompatible and will involve more app changes) or patches
to 3.1.0 in order to compile. Either will be more involved, so just
get builds working again first.

See #58