### PR TITLE
Fix configuration names in Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 # Build XWord
 script:
-  - xcodebuild -project build/xcode4/XWord.xcodeproj -configuration $CONFIGURATION build
+  - xcodebuild -project build/xcode4/XWord.xcodeproj -configuration "$CONFIGURATION Native" build
 
 # For deployed builds, zip the .app folder
 before_deploy:


### PR DESCRIPTION
Previous names didn't actually exist, so both configurations were actually using the default debug configuration.