### PR TITLE
Fix delay opening files on OS X Mojave.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
 # Cache the compiled wxWidgets so it can be in with future builds
 cache:
   directories:
-    - $HOME/wxWidgets
+    - $HOME/wxWidgets-3.1.0
 
 # Run premake4 to create the Xcode project
 before_script:
-  - ./premake4 --platform=x64 --wx-config-debug=$HOME/wxWidgets/bin/wx-config --wx-config-release=$HOME/wxWidgets/bin/wx-config xcode4
+  - ./premake4 --platform=x64 --wx-config-debug=$HOME/wxWidgets-3.1.0/bin/wx-config --wx-config-release=$HOME/wxWidgets-3.1.0/bin/wx-config xcode4
 
 # Build XWord
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ install:
 
 # Cache the compiled wxWidgets so it can be in with future builds
 cache:
-  - '%USERPROFILE%\wxWidgets'
+  - '%USERPROFILE%\wxWidgets-3.1.0'
 
 # Run premake4 to create the Visual Studio project
 before_build:
-  - premake4.exe --platform=x32 --wx-prefix="%USERPROFILE%/wxWidgets" vs2010
+  - premake4.exe --platform=x32 --wx-prefix="%USERPROFILE%/wxWidgets-3.1.0" vs2010
 
 # Build XWord
 build_script:

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -5,7 +5,7 @@ set -e
 
 CONFIGURATION=$1
 
-INSTALL_PATH="$HOME/wxWidgets"
+INSTALL_PATH="$HOME/wxWidgets-3.1.0"
 mkdir -p $INSTALL_PATH
 
 WX_CONFIGURE_FLAGS="\
@@ -48,6 +48,7 @@ if [ ! -d "$INSTALL_PATH/lib" ]; then
   cd wxWidgets-3.1.0
   patch -p1 -i ../wxaui-tweaks.patch
   patch -p1 -i ../wxwidgets-smooth-scroll-modals.patch
+  patch -p1 -i ../wxwidgets-mojave-open-file-delay.patch
   eval $BUILD_COMMAND
 else
   echo "Using cached directory."

--- a/wxwidgets-mojave-open-file-delay.patch
+++ b/wxwidgets-mojave-open-file-delay.patch
@@ -1,0 +1,57 @@
+diff -Naur wxWidgets-3.1.0-old/src/osx/cocoa/utils.mm wxWidgets-3.1.0/src/osx/cocoa/utils.mm
+--- wxWidgets-3.1.0-old/src/osx/cocoa/utils.mm	2016-02-28 13:33:37.000000000 -0800
++++ wxWidgets-3.1.0/src/osx/cocoa/utils.mm	2019-04-21 13:26:16.000000000 -0700
+@@ -68,6 +68,7 @@
+ 
+ - (void)applicationDidFinishLaunching:(NSNotification *)notification
+ {
++    [NSApp stop:nil];
+     wxTheApp->OSXOnDidFinishLaunching();
+ }
+ 
+@@ -323,7 +324,6 @@
+ // here we subclass NSApplication, for the purpose of being able to override sendEvent.
+ @interface wxNSApplication : NSApplication
+ {
+-    BOOL firstPass;
+ }
+ 
+ - (id)init;
+@@ -337,7 +337,7 @@
+ - (id)init
+ {
+     self = [super init];
+-    firstPass = YES;
++    // further init
+     return self;
+ }
+ 
+@@ -366,14 +366,7 @@
+     if ([anEvent type] == NSKeyUp && ([anEvent modifierFlags] & NSCommandKeyMask))
+         [[self keyWindow] sendEvent:anEvent];
+     else
+-        [super sendEvent:anEvent];
+-    
+-    if ( firstPass )
+-    {
+-        [NSApp stop:nil];
+-        firstPass = NO;
+-        return;
+-    }
++        [super sendEvent:anEvent];    
+ }
+ 
+ @end
+@@ -412,12 +405,6 @@
+         appcontroller = OSXCreateAppController();
+         [[NSApplication sharedApplication] setDelegate:(id <NSApplicationDelegate>)appcontroller];
+         [NSColor setIgnoresAlpha:NO];
+-
+-        // calling finishLaunching so early before running the loop seems to trigger some 'MenuManager compatibility' which leads
+-        // to the duplication of menus under 10.5 and a warning under 10.6
+-#if 0
+-        [NSApp finishLaunching];
+-#endif
+     }
+     gNSLayoutManager = [[NSLayoutManager alloc] init];
+     


### PR DESCRIPTION
Bug was identified and fixed upstream in
https://trac.wxwidgets.org/ticket/18305; backport the patch to
wxWidgets 3.1.0 and use it here. Also add wxWidgets version to the
build directory to avoid reusing a cached wxWidgets build without the
patch. In the future, if we add more patches, we can add another
identifier to the directory to identify the set of patches.

Fixes #67