### PR TITLE
Build XWord installer for Windows (#40).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /bin
 /build
 /lib
+/dist/XWord-Windows.exe
+/dist/packages
+/doc/chm
+/doc/html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,13 @@ configuration:
   - Debug
   - Release
 
-# Build and install wxWidgets, with our custom tweaks patch
+environment:
+  PYTHON: "C:\\Python38"
+
+# Build and install markdown and wxWidgets, with our custom tweaks patch
 install:
+  - SET PATH=%PYTHON%;%PATH%
+  - IF %CONFIGURATION%==Release python -m pip install markdown
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
   - bash build-wxwidgets.sh %CONFIGURATION%
 
@@ -21,21 +26,27 @@ before_build:
 # Build XWord
 build_script:
   - msbuild build/vs2010/XWord.sln /p:Configuration=%CONFIGURATION%
+  # For release builds, also build docs and run dist steps.
+  - IF %CONFIGURATION%==Release pushd doc & make_help.cmd & popd
+  - IF %CONFIGURATION%==Release pushd dist & "%ProgramFiles(x86)%\NSIS\makensis.exe" /V4 XWord.nsi & popd
 
-# For deployed builds, zip the build folder
+# Zip the full build folder and make it available as an artifact.
 after_build:
   - 7z a bin\%CONFIGURATION%\XWord-Windows.zip "%APPVEYOR_BUILD_FOLDER%\bin\%CONFIGURATION%\*" -r -x!*.exp -x!*.lib -x!*.pdb -x!*.idb -x!*.ilk -x!*.fbp
 
 artifacts:
-  path: bin\%CONFIGURATION%\XWord-Windows.zip
-  name: XWord-Windows.zip
+  - path: bin\%CONFIGURATION%\XWord-Windows.zip
+    name: XWord-Windows.zip
+
+  - path: dist\XWord-Windows.exe
+    name: XWord-Windows.exe
 
 # Deploy tagged release builds to GitHub Releases
 deploy:
   provider: GitHub
   auth_token:
     secure: di7vtZSm1K8JwmYD0z+PVfcDGav/KwuK4CeBdp4oKoT7ImfJ7ksFSV6zcLcW6qui
-  artifact: XWord-Windows.zip
+  artifact: XWord-Windows.exe
   on:
     appveyor_repo_tag: true
     configuration: Release

--- a/dist/XWord.nsi
+++ b/dist/XWord.nsi
@@ -9,7 +9,7 @@
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
 !define PRODUCT_STARTMENU_REGVAL "NSIS:StartMenuDir"
-!define XWORD_TRUNK "D:\C++\XWord\trunk"
+!define XWORD_TRUNK "..\"
 !define XWORD_BIN "${XWORD_TRUNK}\bin\Release"
 !define VC_REDIST "vc_redist"
 
@@ -144,7 +144,7 @@ FunctionEnd
 ; MUI end ------
 
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
-OutFile "Setup.exe"
+OutFile "XWord-Windows.exe"
 InstallDir "$PROGRAMFILES\XWord" ; This will be overwritten by the portable page
 InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
@@ -166,7 +166,7 @@ Section "MainSection" SEC01
         File "${XWORD_BIN}\puz.dll"
         File "${XWORD_TRUNK}\doc\chm\xword.chm"
         ; LUA
-        File "${XWORD_BIN}\lua5.1.dll"
+        File "${XWORD_BIN}\lua51.dll"
         File "${XWORD_BIN}\luapuz.dll"
         ; Parsers / Misc
         File "${XWORD_BIN}\libexpat.dll"
@@ -176,7 +176,7 @@ Section "MainSection" SEC01
         File "${XWORD_BIN}\libeay32.dll"
         File "${XWORD_BIN}\libssl32.dll"
         ; Info
-        File "${XWORD_TRUNK}\README"
+        File "${XWORD_TRUNK}\README.md"
         File "${XWORD_TRUNK}\AUTHORS"
         File "${XWORD_TRUNK}\COPYING"
         File "${XWORD_TRUNK}\CHANGELOG"
@@ -225,6 +225,7 @@ Section "MainSection" SEC01
         File "${VC_REDIST}\dummy_manifest\Microsoft.VC90.CRT.manifest"
 
         File "${XWORD_TRUNK}\scripts\libs\date.lua"
+        File "${XWORD_TRUNK}\scripts\libs\md5.lua"
         File "${XWORD_TRUNK}\scripts\libs\serialize.lua"
 
         File "${XWORD_TRUNK}\scripts\libs\c-luacurl.dll"
@@ -431,13 +432,13 @@ Section Uninstall
         Delete "$INSTDIR\xword.chm"
         Delete "$INSTDIR\puz.dll"
         Delete "$INSTDIR\luapuz.dll"
-        Delete "$INSTDIR\lua5.1.dll"
+        Delete "$INSTDIR\lua51.dll"
         Delete "$INSTDIR\libcurl.dll"
         Delete "$INSTDIR\libeay32.dll"
         Delete "$INSTDIR\libssl32.dll"
         Delete "$INSTDIR\libexpat.dll"
 
-        Delete "$INSTDIR\README"
+        Delete "$INSTDIR\README.md"
         Delete "$INSTDIR\AUTHORS"
         Delete "$INSTDIR\COPYING"
         Delete "$INSTDIR\CHANGELOG"

--- a/doc/link_check.py
+++ b/doc/link_check.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-print "Checking links . . ."
+print("Checking links . . .")
 
 links = {}
 ids = set()
@@ -27,8 +27,8 @@ for htmlfile in os.listdir('html'):
 # Check broken links
 missing = set(links.keys()) - ids
 if len(missing) > 0:
-    print "Broken links:"
+    print("Broken links:")
     for m in missing:
-        print m, links[m]
+        print(m, links[m])
 else:
-    print "No broken links"
+    print("No broken links")

--- a/doc/make_help.bat
+++ b/doc/make_help.bat
@@ -1,4 +1,0 @@
-markdown.py
-link_check.py
-"%programfiles%\HTML Help Workshop\hhc" chm\help.hhp
-chm\xword.chm

--- a/doc/make_help.cmd
+++ b/doc/make_help.cmd
@@ -1,0 +1,5 @@
+python markdown.py
+python link_check.py
+"%programfiles(x86)%\HTML Help Workshop\hhc" chm\help.hhp
+:: hhc exits with errorlevel = 1 on success - don't treat this as a failure.
+if %errorlevel% equ 1 exit /B 0 else exit /B 1

--- a/doc/markdown.py
+++ b/doc/markdown.py
@@ -68,16 +68,17 @@ def html_escape(text):
     return "".join(html_escape_table.get(c,c) for c in text)
 
 def convert(t):
-    return markdown.markdown(t, ['footnotes', 'tables'])
+    return markdown.markdown(t, extensions=['footnotes', 'tables'])
 
 import sys, os, re, shutil
 
+filepath = sys.path[0]
 if sys.platform == 'win32':
         # We have to remove the Scripts dir from path on windows.
         # If we don't, it will try to import itself rather than markdown lib.
         # This appears to *not* be a problem on *nix systems, only Windows.
         try:
-            sys.path.remove(os.path.dirname(__file__))
+            sys.path.remove(sys.path[0])
         except (ValueError, NameError):
             pass
 
@@ -108,7 +109,7 @@ class ContentsItem:
 contents = {}
 files = []
 
-os.chdir(os.path.dirname(__file__))
+os.chdir(filepath)
 
 # Clear the chm directory and re-make it
 if os.path.exists('chm'):
@@ -122,7 +123,7 @@ for mdfile in os.listdir(os.getcwd()):
     filename = os.path.splitext(mdfile)[0]
     htmlfile = filename + '.html'
     files.append(htmlfile)
-    print 'converting', mdfile
+    print('converting', mdfile)
     with open(mdfile, 'r') as input:
         # Read the first line and make it the title
         title = input.readline().strip()
@@ -138,7 +139,7 @@ for mdfile in os.listdir(os.getcwd()):
         # Search the text for table of contents headings
         contents[filename] = ContentsItem(title, htmlfile)
         if filename not in contents_order:
-            print '"%s" not in contents' % filename
+            print('"%s" not in contents' % filename)
         if filename not in no_ids:
             c = contents[filename]
             level = -1
@@ -214,7 +215,7 @@ with open(os.path.join('chm', 'contents.hhc'), 'w') as f:
 
     def write_item(item):
         f.write("<LI>")
-        f.write('<OBJECT type="text/sitemap">\n' + 
+        f.write('<OBJECT type="text/sitemap">\n' +
                 '    <param name="Name" value="%s">\n'
                 '    <param name="Local" value="%s">\n'
                 '</OBJECT>\n' % (item.name, item.link))


### PR DESCRIPTION
- Fix doc/ python scripts to work on Python 3
- Remove launch step from doc/make_help.bat
- Work around HTML Help Compiler succeeding with code 1
- Use relative paths in dist/XWord.nsi
- Update file list in dist/XWord.nsi
- Add .gitignore for doc + dist outputs
- Add AppVeyor config to run doc + dist steps