### PR TITLE
Add wxWidgets version to the build directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
 # Cache the compiled wxWidgets so it can be in with future builds
 cache:
   directories:
-    - $HOME/wxWidgets
+    - $HOME/wxWidgets-3.1.0
 
 # Run premake4 to create the Xcode project
 before_script:
-  - ./premake4 --platform=x64 --wx-config-debug=$HOME/wxWidgets/bin/wx-config --wx-config-release=$HOME/wxWidgets/bin/wx-config xcode4
+  - ./premake4 --platform=x64 --wx-config-debug=$HOME/wxWidgets-3.1.0/bin/wx-config --wx-config-release=$HOME/wxWidgets-3.1.0/bin/wx-config xcode4
 
 # Build XWord
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,11 +17,11 @@ install:
 
 # Cache the compiled wxWidgets so it can be in with future builds
 cache:
-  - '%USERPROFILE%\wxWidgets'
+  - '%USERPROFILE%\wxWidgets-3.1.0'
 
 # Run premake4 to create the Visual Studio project
 before_build:
-  - premake4.exe --platform=x32 --wx-prefix="%USERPROFILE%/wxWidgets" vs2010
+  - premake4.exe --platform=x32 --wx-prefix="%USERPROFILE%/wxWidgets-3.1.0" vs2010
 
 # Build XWord
 build_script:

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -5,7 +5,7 @@ set -e
 
 CONFIGURATION=$1
 
-INSTALL_PATH="$HOME/wxWidgets"
+INSTALL_PATH="$HOME/wxWidgets-3.1.0"
 mkdir -p $INSTALL_PATH
 
 WX_CONFIGURE_FLAGS="\


### PR DESCRIPTION
Avoids reusing a cached wxWidgets build whenever the version changes. In
the future, if we add patches to the wxWidgets build, or otherwise
change how we build it, we can add another identifier to the directory
to identify the configuration and invalidate old caches.