### PR TITLE
Fix crash when opening a puzzle with debug plugin disabled.

### DIFF
--- a/src/xwordlua.cpp
+++ b/src/xwordlua.cpp
@@ -20,19 +20,12 @@
 #include "paths.hpp"
 
 // Initialize xword lua stuff:
-// Require the luapuz library.
 // Set package.path and package.cpath.
+// Require the luapuz library.
 // Create an xword table with standard paths.
 // Set TASK_INIT global function to initialize secondary threads.
 void lua_openxword(lua_State * L)
 {
-    // Open the luapuz library
-    // NB: We have to use require instead of directly calling luaopen_luapuz
-    // since luapuz is loaded as a dll
-    lua_getglobal(L, "require");
-    lua_pushstring(L, "luapuz");
-    lua_pcall(L, 1, 0, 0);
-
     // Set package.path and package.cpath
     lua_getglobal(L, "package");
 
@@ -44,6 +37,18 @@ void lua_openxword(lua_State * L)
 
     lua_pop(L, 1);
 
+    // Open the luapuz library
+    // NB: We have to use require instead of directly calling luaopen_luapuz
+    // since luapuz is loaded as a shared library.
+    lua_getglobal(L, "require");
+    lua_pushstring(L, "luapuz");
+    if (lua_pcall(L, 1, 0, 0) != 0) {
+        if (lua_isstring(L, -1))
+            wxLogDebug("Error loading luapuz library: %s", lua_tostring(L, -1));
+        else
+            wxLogDebug("Unknown error loading luapuz library");
+        lua_pop(L, 1);
+    }
 
     // Set values in xword table:
     //    configdir


### PR DESCRIPTION
Normally the luapuz library would be loaded by lua_openxword prior to
any use of Lua. However, on Mac (at least), the library would fail to
load because it would be loaded prior to the package path being set.
This was fine as long as the debug plugin was enabled, since the debug
plugin also loads luapuz and is initialized after the package path is
set. However, with the plugin disabled, nothing loads luapuz, and we
fail to push a Puzzle onto the Lua stack.

Swap the loading order to ensure that luapuz loads successfully, even
if the debug plugin is disabled. Also log a warning when the loading
fails to make future issues clearer. Note that we can't use
LogLuaMessage here without further tweaks because plugins are loaded
on a background thread, and setting the message count can't be done on
a background thread.

Fixes #60