### PR TITLE
Mitigate race condition in curl initialization.

### DIFF
--- a/scripts/xword/init.lua
+++ b/scripts/xword/init.lua
@@ -54,6 +54,17 @@ function mod_path(path, level)
     return path .. '.'
 end
 
+-- Setup curl
+-- luacurl initialization will call curl_global_init; per
+-- https://curl.haxx.se/libcurl/c/threadsafe.html, we must do this before
+-- starting any other threads (as is done by the task library) to ensure it
+-- completes before anything else attempts to use curl. This isn't 100%
+-- sufficient - curl_global_init may call other thread-unsafe methods (e.g.
+-- SSL init methods), leading to issues if anything else is using those methods.
+-- But it's the best we can do here, and nothing else should be making network
+-- requests except for lua plugins.
+require 'luacurl'
+
 -- Setup task library
 local task = require 'task'
 task.error_handler = xword.logerror


### PR DESCRIPTION
curl_global_init is not thread-safe - not only is it not supposed to
be called in more than one thread at the same time, but since it
itself makes calls to thread-unsafe APIs (e.g. in SSL libraries) that
may also be used outside of curl, it's technically not safe to be
doing *anything* on any other thread at the same time.

However, lua initialization starts up various background tasks using
the task API, which spawns new threads for each task, and those tasks
depend on curl. For example, the package manager is started to check
for updates. Curl is also loaded on the main thread in parallel.

To mitigate this problem, we can explicitly require luacurl (and thus
call curl_global_init) prior to loading the task library (and thus
starting background thrads which might call curl_global_init). At this
point, no other threads should be running, or at least not making HTTP
requests. From that point forward, libcurl keeps a reference count and
should prevent further calls from curl_global_init from doing
anything.

Fixes #57