### PR TITLE
Improve clue prompt rendering performance.

### DIFF
--- a/src/widgets/HtmlText.cpp
+++ b/src/widgets/HtmlText.cpp
@@ -209,22 +209,23 @@ void HtmlText::LayoutCell()
         }
         else // ! HT_NOWRAP
         {
-            // Increase cell size
-            while (pointSize < m_maxFontSize
-                   && (m_cell->GetHeight() < height
-                       || m_cell->GetWidth() < width))
-            {
-                Parse(label, ++pointSize, faceName);
+            // Binary search to find the highest point size where the text still fits.
+            int lowerBound = m_minFontSize;
+            int upperBound = m_maxFontSize;
+            while (lowerBound != upperBound) {
+                pointSize = (lowerBound + upperBound + 1) / 2;
+                Parse(label, pointSize, faceName);
                 m_cell->Layout(width);
+                if (m_cell->GetHeight() < height) {
+                    lowerBound = pointSize;
+                }
+                else {
+                    upperBound = pointSize - 1;
+                }
             }
-            // Decrease cell size
-            while (pointSize > m_minFontSize
-                   && (m_cell->GetHeight() > height
-                       || m_cell->GetWidth() > width))
-            {
-                Parse(label, --pointSize, faceName);
-                m_cell->Layout(width);
-            }
+            pointSize = lowerBound;
+            Parse(label, pointSize, faceName);
+            m_cell->Layout(width);
         }
     }
     // Set m_layoutWidth

--- a/src/widgets/HtmlText.hpp
+++ b/src/widgets/HtmlText.hpp
@@ -84,6 +84,11 @@ public:
 
     virtual void SetLabel(const wxString & label)
     {
+        wxString currentLabel = wxControl::GetLabel();
+        if (currentLabel == label) {
+            // Avoid flicker if the label hasn't changed.
+            return;
+        }
         wxControl::SetLabel(label);
         LayoutCell();
         Refresh();


### PR DESCRIPTION
On a Windows device with a high-density display, it was taking
hundreds of milliseconds to update from one clue to another. Rather
than run a linear search for the optimal font size, we can do a binary
search instead, ensuring we only need
log(maxFontSize-minFontSize)/log(2) layout passes.

We can also avoid any work if the clue text hasn't changed, e.g. if
we're navigating within the same word. This helps reduce unnecessary
flicker.

See #82