### PR TITLE
Fix initial window positioning on Windows.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -1710,8 +1710,11 @@ MyFrame::SaveWindowConfig()
             // Make sure the sizes are within acceptable bounds
             if (w < 200) w = 500;
             if (h < 200) h = 500;
-            if (x < 0 || x >= wxSystemSettings::GetMetric(wxSYS_SCREEN_X)) x = 20;
-            if (y < 0 || y >= wxSystemSettings::GetMetric(wxSYS_SCREEN_Y)) y = 20;
+            // For some reason on Windows with wxWidgets 3.1.2, xleft alignment of the window
+            // results in slightly negative coordinates. So only snap the window back to the
+            // screen if it is significantly off screen.
+            if (x < -200 || x >= wxSystemSettings::GetMetric(wxSYS_SCREEN_X)) x = 20;
+            if (y < -200 || y >= wxSystemSettings::GetMetric(wxSYS_SCREEN_Y)) y = 20;
             config.Window.width = w;
             config.Window.height = h;
             config.Window.top = y;


### PR DESCRIPTION
For some reason, on Windows with wxWidgets 3.1.3, a window at the left
edge of the screen has a small negative left coordinate instead of 0
as expected. Rather than snap negative positions to 20 pixels, we
allow slightly negative positions without repositioning them on the
next startup. We still reposition windows that are significantly
offscreen in case this was unintentional or the saved position was
invalid.

Fixes #84