### PR TITLE
Fix metadata corruption when saving JPZ files.

### DIFF
--- a/puz/Puzzle.hpp
+++ b/puz/Puzzle.hpp
@@ -82,8 +82,8 @@ public:
         metamap_t::const_iterator it = m_metadata.find(name);
         if (it == m_metadata.end())
         {
-            // Return an empty string (created on demand).
-            return (const_cast<Puzzle *>(this)->m_metadata)[puzT("")];
+            const static string_t empty_string = puzT("");
+            return empty_string;
         }
         return it->second;
     }


### PR DESCRIPTION
When Puzzle.GetMeta was called for a key which didn't exist, it would
write an entry with an empty key and value into the metadata table. JPZ
serialization would convert this into an "<:anonymous />" XML tag which
is invalid in the JPZ specification and which breaks the Crossword Nexus
parser. By skipping this modification and leaving the metadata table
untouched, we prevent this invalid tag from being written.

See discussion in #66