### PR TITLE
Fix writing of mixed content in JPZ clues.

### DIFF
--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -42,6 +42,16 @@ protected:
     zip::File & m_file;
 };
 
+void AppendChildWithSpanWrapping(xml::node parent, int child_count, xml::node child) {
+    if (child_count > 1 && child.type() == pugi::xml_node_type::node_pcdata) {
+        // When writing mixed content, plain text must be wrapped in <span> tags.
+        xml::node span = parent.append_child("span");
+        span.append_copy(child);
+    } else {
+        parent.append_copy(child);
+    }
+}
+
 //-----------------------------------------------------------------------------
 // SaveJpz
 //-----------------------------------------------------------------------------
@@ -236,7 +246,7 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
                 clue.append_attribute("number") =
                     encode_utf8(it->GetNumber()).c_str();
                 clue.append_attribute("word") = wordMap[&it->GetWord()];
-                xml::SetInnerXML(clue, it->GetText());
+                xml::SetInnerXML(clue, it->GetText(), &AppendChildWithSpanWrapping);
             }
         }
     }

--- a/puz/parse/xml.cpp
+++ b/puz/parse/xml.cpp
@@ -157,8 +157,11 @@ void SetInnerXML(node n, const string_t & innerxml)
     pugi::xml_parse_result result = doc.load(temp.c_str());
     if (! result)
         SetText(n, innerxml);
-    else
-        n.append_copy(doc.first_child().first_child());
+    else {
+        for (node child = doc.first_child().first_child(); child; child = child.next_sibling()) {
+            n.append_copy(child);
+        }
+    }
 }
 
 } // namespace xml

--- a/puz/parse/xml.cpp
+++ b/puz/parse/xml.cpp
@@ -146,7 +146,16 @@ string_t Parser::GetInnerXML(node n)
     return decode_utf8(stream.str());
 }
 
-void SetInnerXML(node n, const string_t & innerxml)
+static void AppendChild(node parent, int child_count, node child)
+{
+    parent.append_copy(child);
+}
+
+void SetInnerXML(node node, const string_t& innerxml) {
+    SetInnerXML(node, innerxml, &AppendChild);
+}
+
+void SetInnerXML(node n, const string_t & innerxml, void (*append_fn)(xml::node, int, xml::node))
 {
     // Parse the XML, and add it as a child.
     // We need to add a dummy xml wrapper element so that plain text still
@@ -158,8 +167,9 @@ void SetInnerXML(node n, const string_t & innerxml)
     if (! result)
         SetText(n, innerxml);
     else {
+        int child_count = std::distance(doc.first_child().begin(), doc.first_child().end());
         for (node child = doc.first_child().first_child(); child; child = child.next_sibling()) {
-            n.append_copy(child);
+            append_fn(n, child_count, child);
         }
     }
 }

--- a/puz/parse/xml.hpp
+++ b/puz/parse/xml.hpp
@@ -108,8 +108,13 @@ inline void SetText(node node, const string_t & text)
 {
     SetText(node, encode_utf8(text).c_str());
 }
+void SetInnerXML(node node, const string_t& innerxml);
 
-void SetInnerXML(node node, const string_t & innerxml);
+// Version of SetInnerXML with a custom function to append each parsed node of innerxml.
+// append_fn takes the parent node, the total child count, and the child node.
+void SetInnerXML(node node,
+                 const string_t & innerxml,
+                 void (*append_fn)(xml::node, int, xml::node));
 
 inline void Append(node node, const char * name, const char * value)
 {


### PR DESCRIPTION
This offers a bit more flexibility to support JPZ files with clues that
are only partially formatted, e.g. "<i>italicized part</i> unformatted
part". While the spec suggests that mixed content is "not supported",
and indeed Puzzle Solver can't handle such content, the online solver at
Crossword Nexus does handle it, and without such support, we'd lose the
ability to have italicized titles in clues when importing .rgz files.

See #86