### PR TITLE
Use wxWidgets' built-in libpng/jpeg/tiff on Mac.

### DIFF
--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -18,6 +18,9 @@ WX_CONFIGURE_FLAGS="\
   --disable-shared \
   --enable-compat28 \
   --with-macosx-version-min=10.7 \
+  --with-libpng=builtin \
+  --with-libjpeg=builtin \
+  --with-libtiff=builtin \
   CFLAGS=-fvisibility-inlines-hidden \
   CXXFLAGS='-fvisibility-inlines-hidden -stdlib=libc++' \
   CPPFLAGS='-fvisibility-inlines-hidden -stdlib=libc++' \


### PR DESCRIPTION
These libraries are not built into OS X by default, so you'd need to
install them via homebrew first, and there may be version
inconsistencies. This makes the OS X binary easier to distribute.