### PR TITLE
Disable smart quotes in metadata settings text boxes.

### DIFF
--- a/src/dialogs/TreePanels.hpp
+++ b/src/dialogs/TreePanels.hpp
@@ -331,6 +331,11 @@ public:
         // a long string
         m_format->SetInitialSize(wxSize(250, m_format->GetCharHeight() * 7));
 
+#ifdef __WXOSX__
+        // Since this might be a script, don't let OS X substitute fancy quotes.
+        m_format->OSXEnableAutomaticQuoteSubstitution(false);
+#endif
+
         // Use Lua checkbox
         m_useLua = AddConfigControl(new ConfigControl<bool>(meta.useLua));
         m_useLua->SetLabel("Script");


### PR DESCRIPTION
Since these can be scripts, we don't want fancy quotes to be
automatically substituted.

This bug also impacts some of the xworddebug lua plugin UI, but this
would be harder to fix since the generated bindings don't include
WXOSX-specific methods, and this is less impactful since it's debug
only.

See #70