### PR TITLE
Fix Newsday .txt import word generation.

### DIFF
--- a/scripts/import/newsday.lua
+++ b/scripts/import/newsday.lua
@@ -71,8 +71,8 @@ local function parse(p, f)
     -- Set the clues
     p:SetClueList("Across", across)
     p:SetClueList("Down", down)
-    p:NumberGrid()
     p:NumberClues()
+    p:NumberGrid()
 end
 
 function import.Newsday(p, filename)


### PR DESCRIPTION
Previously, the script called NumberGrid() before NumberClues(). This is
broken because NumberGrid() will call GenerateWords() to generate words
for each clue; however, at this point, the clues are numbered
incorrectly (sequentially) because NumberClues hasn't been called yet.
Fix this by first generating the correct clue numbers before numbering
the grid and generating the clue words.

uClick XML import has the same order, but is not impacted because uClick
XML already includes the clue numbers for each clue.