### PR TITLE
Complete configuration for auto updater.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,16 @@ before_deploy:
   - pushd bin/$CONFIGURATION
   - zip -r XWord-macOS.zip XWord.app/ -x *.fbp -x "*/scripts/_*" -x "*/scripts/*debug*"
   - popd
+  - sed -e "s/{VERSION}/${XWORD_VERSION}/" -e "s/{OS_FILE}/XWord-macOS.zip/" dist/packages_template.lua > dist/packages_mac.lua
 
 # Deploy tagged release builds to GitHub Releases
 deploy:
   provider: releases
   api_key:
     secure: dT5W1MsTMFYjN6mDnSqpL7QjHkL/R6When5elNX9dwGLafCyRN2ohAUa6lpt17v8NG3//qF9BZLZOymA7D9kNqILGbt8mjCu053WBknekI9BTG593HQhsV2y0nA8p2J3y95/Qdty/t0jg/QdWqV60O0w6VQFGoHOb9EUVKCu9cR+WX4kVz2uadB8ms8r2YDeC0fUnrA/w1XnopohJw3P/hiV6S2+u1eeWFFyjOTuTJcyg6cHkxMysj/4N4llxOU/to0/nQYKg+sc9B7hHLFmwHxLbq1prn9LG9kRwDmCnzNlV0OgPOT2vP+LSwyfvp4zuHNC61sIH8OSVKCmn3keM/ZDahKB37Zd0eQKBxLNm9iu/UibBN7R+4QtVXgPkfqZb9bFhpy9fi+MxiYXUzbl3q3p7werLooI42KFzkJ2KxSkP3ZEQko3XsdAdgeBZVXzD/Ze0IMnaTQSeCPQbzbMjXA0mIwOkWCIj77dqOnQOdjAURA+U5tUt1Q2TUa9yJHXT5O6J2XNXdCbM5JlzBNoo9orcTjuwnsyplvMovKw1Qx0DGVG0hNakp2tNszsH4LeJKrAdWr1KXGu392Shq3XCya3X76jhQBO9zMDAe0txdFpnmx6Pi8GYlFabU2OWoWmNsnJVxOsMGKL8wz1vRx4uakFY4WzgDO/SI/6zkQ43W8=
-  file: bin/$CONFIGURATION/XWord-macOS.zip
+  file:
+    - bin/$CONFIGURATION/XWord-macOS.zip
+    - dist/packages_mac.lua
   skip_cleanup: true
   on:
     tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ build_script:
   # For release builds, also build docs and run dist steps.
   - IF %CONFIGURATION%==Release pushd doc & make_help.cmd & popd
   - IF %CONFIGURATION%==Release pushd dist & python gen_nsis.py > scripts.nsi & "%ProgramFiles(x86)%\NSIS\makensis.exe" /V4 XWord.nsi & popd
+  - IF %CONFIGURATION%==Release sed -e "s/{VERSION}/%XWORD_VERSION%/" -e "s/{OS_FILE}/XWord-Windows.exe/" dist/packages_template.lua > dist/packages_windows.lua
 
 # Zip the full build folder and make it available as an artifact.
 after_build:
@@ -45,12 +46,15 @@ artifacts:
   - path: dist\XWord-Windows.exe
     name: XWord-Windows.exe
 
+  - path: dist\packages_windows.lua
+    name: packages_windows.lua
+
 # Deploy tagged release builds to GitHub Releases
 deploy:
   provider: GitHub
   auth_token:
     secure: di7vtZSm1K8JwmYD0z+PVfcDGav/KwuK4CeBdp4oKoT7ImfJ7ksFSV6zcLcW6qui
-  artifact: XWord-Windows.exe
+  artifact: XWord-Windows.exe,packages_windows.lua
   on:
     appveyor_repo_tag: true
     configuration: Release

--- a/dist/packages_template.lua
+++ b/dist/packages_template.lua
@@ -1,0 +1,7 @@
+return {
+  xword = {
+    download = "https://github.com/mrichards42/xword/releases/download/{VERSION}/{OS_FILE}",
+    name = "XWord",
+    version = "{VERSION}",
+  },
+}

--- a/scripts/xword/pkgmgr/updater/init.lua
+++ b/scripts/xword/pkgmgr/updater/init.lua
@@ -26,7 +26,7 @@ if not task.is_main then return P end
 
 -- Check for an update.  Callback is called after the task executes
 local osname = wx.__WXMSW__ and 'windows' or wx.__WXMAC__ and 'mac' or 'linux'
-P.packages_url = "http://sourceforge.net/projects/wx-xword/files/scripts/packages_"..osname..".lua"
+P.packages_url = "https://mrichards42.github.io/xword/packages_"..osname..".lua"
 
 function P.CheckForUpdates(callback)
     -- Make sure we have a directory for the updates file


### PR DESCRIPTION
- Generate packages_windows.lua and packages_mac.lua as part of release
builds and include them in the release artifacts. For now, since we are
only distributing plugins inside the distribution, we can use a simple
template and a sed-based find/replace to generate these files.
dist/gen_packages.lua works for this purpose as well, but requires Lua
to be installed in the CI environment, which is non-trivial. We can
always revisit if we decide to distribute plugin packages separately.

- Point the auto-updater to a known location on GitHub pages to search
for new packages.

With this along with #102 and #103 (along with #106 for Windows), the
full distribution workflow is functional on Windows/Mac. Pushing a new
build consists of the following steps:

1) Create a GitHub release. Set the tag to a valid release number, e.g.
"0.7.0".
2) Wait for CI builds to complete successfully on AppVeyor (Windows) and
Travis CI (Mac).
3) Validate that the builds are functioning as expected.
4) Download packages_windows.lua and packages_mac.lua from the builds to
docs/, commit, and push (to master). This will cause the new build to go
"live" and start showing up for auto updates.

See #40