### PR TITLE
Initial work on Acrostic support.

### DIFF
--- a/lua/luapuz/bind/luapuz_puz.cpp
+++ b/lua/luapuz/bind/luapuz_puz.cpp
@@ -144,6 +144,7 @@ const luapuz_enumReg GextFlag_reg[] = {
     {"FLAG_MISSING", puz::FLAG_MISSING},
     {"FLAG_CORRECT", puz::FLAG_CORRECT},
     {"FLAG_THEME", puz::FLAG_THEME},
+    {"FLAG_CLUE", puz::FLAG_CLUE},
     {"FLAG_CHECK_MASK", puz::FLAG_CHECK_MASK},
     {NULL, NULL}
 };
@@ -182,6 +183,7 @@ const char * GridType_meta = "puz.GridType";
 const luapuz_enumReg GridType_reg[] = {
     {"TYPE_NORMAL", puz::TYPE_NORMAL},
     {"TYPE_DIAGRAMLESS", puz::TYPE_DIAGRAMLESS},
+    {"TYPE_ACROSTIC", puz::TYPE_ACROSTIC},
     {NULL, NULL}
 };
 

--- a/lua/luapuz/bind/luapuz_puz.cpp
+++ b/lua/luapuz/bind/luapuz_puz.cpp
@@ -144,7 +144,7 @@ const luapuz_enumReg GextFlag_reg[] = {
     {"FLAG_MISSING", puz::FLAG_MISSING},
     {"FLAG_CORRECT", puz::FLAG_CORRECT},
     {"FLAG_THEME", puz::FLAG_THEME},
-    {"FLAG_CLUE", puz::FLAG_CLUE},
+    {"FLAG_ANNOTATION", puz::FLAG_ANNOTATION},
     {"FLAG_CHECK_MASK", puz::FLAG_CHECK_MASK},
     {NULL, NULL}
 };

--- a/lua/luapuz/bind/luapuz_puz_Grid.cpp
+++ b/lua/luapuz/bind/luapuz_puz_Grid.cpp
@@ -288,6 +288,14 @@ static int Grid_IsDiagramless(lua_State * L)
     lua_pushboolean(L, returns);
     return 1;
 }
+// bool IsAcrostic()
+static int Grid_IsAcrostic(lua_State * L)
+{
+    puz::Grid * grid = luapuz_checkGrid(L, 1);
+    bool returns = grid->IsAcrostic();
+    lua_pushboolean(L, returns);
+    return 1;
+}
 // unsigned short GetType()
 static int Grid_GetType(lua_State * L)
 {
@@ -475,6 +483,7 @@ static const luaL_reg Gridlib[] = {
     {"GetFlag", Grid_GetFlag},
     {"SetFlag", Grid_SetFlag},
     {"IsDiagramless", Grid_IsDiagramless},
+    {"IsAcrostic", Grid_IsAcrostic},
     {"GetType", Grid_GetType},
     {"SetType", Grid_SetType},
     {"ScrambleSolution", Grid_ScrambleSolution},

--- a/lua/luapuz/bind/luapuz_puz_Square.cpp
+++ b/lua/luapuz/bind/luapuz_puz_Square.cpp
@@ -654,21 +654,21 @@ static int Square_SetTheme(lua_State * L)
     square->SetTheme(doit);
     return 0;
 }
-// bool IsClue()
-static int Square_IsClue(lua_State * L)
+// bool IsAnnotation()
+static int Square_IsAnnotation(lua_State * L)
 {
     puz::Square * square = luapuz_checkSquare(L, 1);
-    bool returns = square->IsClue();
+    bool returns = square->IsAnnotation();
     lua_pushboolean(L, returns);
     return 1;
 }
-// void SetClue(bool doit = true)
-static int Square_SetClue(lua_State * L)
+// void SetAnnotation(bool doit = true)
+static int Square_SetAnnotation(lua_State * L)
 {
     puz::Square * square = luapuz_checkSquare(L, 1);
     int argCount = lua_gettop(L);
     bool doit = (argCount >= 2 ? luapuz_checkboolean(L, 2) : true);
-    square->SetClue(doit);
+    square->SetAnnotation(doit);
     return 0;
 }
 // bool HasColor()
@@ -836,8 +836,8 @@ static const luaL_reg Squarelib[] = {
     {"SetMissing", Square_SetMissing},
     {"IsTheme", Square_IsTheme},
     {"SetTheme", Square_SetTheme},
-    {"IsClue", Square_IsClue},
-    {"SetClue", Square_SetClue},
+    {"IsAnnotation", Square_IsAnnotation},
+    {"SetAnnotation", Square_SetAnnotation},
     {"HasColor", Square_HasColor},
     {"SetColor", Square_SetColor},
     {"GetHtmlColor", Square_GetHtmlColor},

--- a/lua/luapuz/bind/luapuz_puz_Square.cpp
+++ b/lua/luapuz/bind/luapuz_puz_Square.cpp
@@ -654,6 +654,23 @@ static int Square_SetTheme(lua_State * L)
     square->SetTheme(doit);
     return 0;
 }
+// bool IsClue()
+static int Square_IsClue(lua_State * L)
+{
+    puz::Square * square = luapuz_checkSquare(L, 1);
+    bool returns = square->IsClue();
+    lua_pushboolean(L, returns);
+    return 1;
+}
+// void SetClue(bool doit = true)
+static int Square_SetClue(lua_State * L)
+{
+    puz::Square * square = luapuz_checkSquare(L, 1);
+    int argCount = lua_gettop(L);
+    bool doit = (argCount >= 2 ? luapuz_checkboolean(L, 2) : true);
+    square->SetClue(doit);
+    return 0;
+}
 // bool HasColor()
 static int Square_HasColor(lua_State * L)
 {
@@ -819,6 +836,8 @@ static const luaL_reg Squarelib[] = {
     {"SetMissing", Square_SetMissing},
     {"IsTheme", Square_IsTheme},
     {"SetTheme", Square_SetTheme},
+    {"IsClue", Square_IsClue},
+    {"SetClue", Square_SetClue},
     {"HasColor", Square_HasColor},
     {"SetColor", Square_SetColor},
     {"GetHtmlColor", Square_GetHtmlColor},

--- a/lua/luapuz/bind/puz_defs.lua
+++ b/lua/luapuz/bind/puz_defs.lua
@@ -51,7 +51,7 @@ enum{ "GextFlag", header="puz/Square.hpp",
     "FLAG_MISSING",
     "FLAG_CORRECT",
     "FLAG_THEME",
-    "FLAG_CLUE",
+    "FLAG_ANNOTATION",
 
     "FLAG_CHECK_MASK",
 }
@@ -141,8 +141,8 @@ class{"Square", header="puz/Square.hpp"}
     func{"IsTheme", returns="bool"}
     func{"SetTheme", arg("bool", "doit", "true")}
 
-    func{"IsClue", returns="bool"}
-    func{"SetClue", arg("bool", "doit", "true")}
+    func{"IsAnnotation", returns="bool"}
+    func{"SetAnnotation", arg("bool", "doit", "true")}
 
     func{"HasColor", returns="bool"}
     func{"SetColor", arg("unsigned char", "red"),

--- a/lua/luapuz/bind/puz_defs.lua
+++ b/lua/luapuz/bind/puz_defs.lua
@@ -51,6 +51,7 @@ enum{ "GextFlag", header="puz/Square.hpp",
     "FLAG_MISSING",
     "FLAG_CORRECT",
     "FLAG_THEME",
+    "FLAG_CLUE",
 
     "FLAG_CHECK_MASK",
 }
@@ -69,6 +70,7 @@ enum { "GridFlag", header="puz/Grid.hpp",
 enum { "GridType", header="puz/Grid.hpp",
     "TYPE_NORMAL",
     "TYPE_DIAGRAMLESS",
+    "TYPE_ACROSTIC",
 }
 
 enum { "FindOptions", header="puz/Grid.hpp",
@@ -138,6 +140,9 @@ class{"Square", header="puz/Square.hpp"}
 
     func{"IsTheme", returns="bool"}
     func{"SetTheme", arg("bool", "doit", "true")}
+
+    func{"IsClue", returns="bool"}
+    func{"SetClue", arg("bool", "doit", "true")}
 
     func{"HasColor", returns="bool"}
     func{"SetColor", arg("unsigned char", "red"),
@@ -225,6 +230,7 @@ class{"Grid", header="puz/Grid.hpp"}
     property{"unsigned short", "Flag"}
 
     func{"IsDiagramless", returns="bool"}
+    func{"IsAcrostic", returns="bool"}
     property{"unsigned short", "Type"}
 
     func{"ScrambleSolution", returns="bool", arg("unsigned short", "key", "0")}

--- a/puz/Grid.cpp
+++ b/puz/Grid.cpp
@@ -51,6 +51,8 @@
 #include "iterator.hpp"
 #include "Scrambler.hpp"
 
+#include <map>
+
 namespace puz {
 
 
@@ -126,7 +128,9 @@ Grid::SetupIteration()
     // Fill in Square members:
     //   - Row and Col
     //   - Next
+    //   - Partner (for Acrostics)
     //-------------------------------------------------------------------
+    std::map<string_t, Square*> partner_map;
     for (size_t row = 0; row < GetHeight(); ++row)
     {
         for (size_t col = 0; col < GetWidth(); ++col)
@@ -134,6 +138,17 @@ Grid::SetupIteration()
             Square & square = At(col, row);
             square.m_col = col;
             square.m_row = row;
+
+            if (IsAcrostic() && square.HasNumber()) {
+                std::map<string_t, Square*>::iterator it = partner_map.find(square.GetNumber());
+                if (it == partner_map.end()) {
+                    partner_map[square.GetNumber()] = &square;
+                } else {
+                    Square* partner = it->second;
+                    square.m_partner = partner;
+                    partner->m_partner = &square;
+                }
+            }
 
             // Special cases for width or height == 1
             if (GetHeight() == 1 && GetWidth() == 1)

--- a/puz/Grid.cpp
+++ b/puz/Grid.cpp
@@ -128,9 +128,7 @@ Grid::SetupIteration()
     // Fill in Square members:
     //   - Row and Col
     //   - Next
-    //   - Partner (for Acrostics)
     //-------------------------------------------------------------------
-    std::map<string_t, Square*> partner_map;
     for (size_t row = 0; row < GetHeight(); ++row)
     {
         for (size_t col = 0; col < GetWidth(); ++col)
@@ -138,17 +136,6 @@ Grid::SetupIteration()
             Square & square = At(col, row);
             square.m_col = col;
             square.m_row = row;
-
-            if (IsAcrostic() && square.HasNumber()) {
-                std::map<string_t, Square*>::iterator it = partner_map.find(square.GetNumber());
-                if (it == partner_map.end()) {
-                    partner_map[square.GetNumber()] = &square;
-                } else {
-                    Square* partner = it->second;
-                    square.m_partner = partner;
-                    partner->m_partner = &square;
-                }
-            }
 
             // Special cases for width or height == 1
             if (GetHeight() == 1 && GetWidth() == 1)
@@ -281,6 +268,31 @@ void Grid::NumberGrid()
             square->SetNumber(clueNumber++);
         else
             square->SetNumber(puzT(""));
+    }
+}
+
+void
+Grid::FindPartnerSquares()
+{
+    if (!IsAcrostic()) return;
+    std::map<string_t, Square*> partner_map;
+    for (size_t row = 0; row < GetHeight(); ++row)
+    {
+        for (size_t col = 0; col < GetWidth(); ++col)
+        {
+            Square& square = At(col, row);
+            if (square.HasNumber()) {
+                std::map<string_t, Square*>::iterator it = partner_map.find(square.GetNumber());
+                if (it == partner_map.end()) {
+                    partner_map[square.GetNumber()] = &square;
+                }
+                else {
+                    Square* partner = it->second;
+                    square.m_partner = partner;
+                    partner->m_partner = &square;
+                }
+            }
+        }
     }
 }
 

--- a/puz/Grid.hpp
+++ b/puz/Grid.hpp
@@ -89,6 +89,9 @@ public:
     // Algorithmically determine grid numbers
     void NumberGrid();
 
+    // Find and fill in partner squares (for Acrostics)
+    void FindPartnerSquares();
+
 public:
 
     // Size

--- a/puz/Grid.hpp
+++ b/puz/Grid.hpp
@@ -38,8 +38,11 @@ enum GridFlag
 
 enum GridType
 {
+    // Across Lite flags
     TYPE_NORMAL      = 0x0001,
-    TYPE_DIAGRAMLESS = 0x0401
+    TYPE_DIAGRAMLESS = 0x0401,
+    // Additional flags
+    TYPE_ACROSTIC    = 0x1000,
 };
 
 // Parameters for FindSquare
@@ -186,6 +189,7 @@ public:
 
     // Type
     bool IsDiagramless() const { return m_type == TYPE_DIAGRAMLESS; }
+    bool IsAcrostic() const { return m_type == TYPE_ACROSTIC; }
     unsigned short GetType() const { return m_type; }
     void SetType(unsigned short type) { m_type = type; }
 

--- a/puz/Puzzle.cpp
+++ b/puz/Puzzle.cpp
@@ -42,6 +42,7 @@ Puzzle::DoLoad(const std::string & filename, const FileHandlerDesc * desc)
             GenerateWords();
         MarkThemeSquares();
         FixMalformattedDiagramless();
+        m_grid.FindPartnerSquares();
         TestOk();
     }
     catch (std::ios::failure &) {

--- a/puz/Square.cpp
+++ b/puz/Square.cpp
@@ -384,7 +384,7 @@ void Square::RemoveColor()
 // Square text and solution
 //------------------------------------------------------------------------------
 
-void Square::SetText(const string_t & text)
+void Square::SetText(const string_t & text, bool propagate)
 {
     if (text.empty())
         m_text = Blank;
@@ -392,6 +392,9 @@ void Square::SetText(const string_t & text)
         m_text = text;
     else
         m_text = ToGrid(text);
+    if (propagate && m_partner != NULL) {
+        m_partner->SetText(text, false);
+    }
 }
 
 void Square::SetSolution(const string_t & solution)

--- a/puz/Square.hpp
+++ b/puz/Square.hpp
@@ -51,7 +51,7 @@ enum GextFlag
     FLAG_MISSING   = 0x200, // No square
     FLAG_CORRECT   = 0x400, // Checked/correct
     FLAG_THEME     = 0x800, // A theme square
-    FLAG_CLUE      = 0x1000, // A clue square
+    FLAG_ANNOTATION      = 0x1000, // An annotation square (aka "clue" square in JPZ)
 
     // Check square options
     FLAG_CHECK_MASK = FLAG_X |
@@ -189,11 +189,11 @@ public:
     // consistency, so if your puzzle is diagramless, you will have to
     // explicitly call SetText("") on black squares to make them empty.
     bool IsWhite()         const { return !IsBlack() && !IsMissing(); }
-    bool IsBlack()         const { return m_text == Black || IsClue(); }
+    bool IsBlack()         const { return m_text == Black || IsAnnotation(); }
     bool IsBlank()         const { return m_text == Blank; }
     // Corresponding functions for the solution
     bool IsSolutionWhite() const { return !IsSolutionBlack() && !IsMissing(); }
-    bool IsSolutionBlack() const { return m_solution == Black || IsClue(); }
+    bool IsSolutionBlack() const { return m_solution == Black || IsAnnotation(); }
     bool IsSolutionBlank() const { return m_solution == Blank; }
 
     // Text
@@ -286,8 +286,8 @@ public:
     bool IsTheme() const { return HasFlag(FLAG_THEME); }
     void SetTheme(bool doit = true) { AddFlag(FLAG_THEME, doit); }
 
-    bool IsClue() const { return HasFlag(FLAG_CLUE); }
-    void SetClue(bool doit = true) { AddFlag(FLAG_CLUE, doit); }
+    bool IsAnnotation() const { return HasFlag(FLAG_ANNOTATION); }
+    void SetAnnotation(bool doit = true) { AddFlag(FLAG_ANNOTATION, doit); }
 
     bool HasColor() const { return HasFlag(FLAG_COLOR); }
     void SetColor(unsigned char red, unsigned char green, unsigned char blue);

--- a/puz/Square.hpp
+++ b/puz/Square.hpp
@@ -203,7 +203,7 @@ public:
     const string_t & GetText()     const { return m_text; }
     const string_t & GetSolution() const { return m_solution; }
 
-    void SetText    (const string_t & text);
+    void SetText    (const string_t & text, bool propagate = true);
     void SetSolution(const string_t & solution);
     void SetSolution(const string_t & solution, char plain);
     void SetPlainSolution(char plain); // Leave solution rebus unchanged
@@ -262,14 +262,19 @@ public:
 
     // Flags
     //------
-    void         SetFlag (unsigned int flag) { m_flag = flag; }
+    void         SetFlag (unsigned int flag, bool propagate = true) {
+        m_flag = flag;
+        if (propagate && m_partner) {
+            m_partner->SetFlag(flag, false);
+        }
+    }
     unsigned int GetFlag() const             { return m_flag; }
     bool         HasFlag(unsigned int flag) const
         { return (m_flag & flag) != 0; }
 
     void   AddFlag     (unsigned int flag, bool doit = true)
     {
-        doit ? m_flag |= flag : m_flag &= ~ flag;
+        SetFlag(doit ? m_flag | flag : m_flag & ~ flag);
     }
     void   RemoveFlag  (unsigned int flag) { AddFlag(flag, false); }
     void   ToggleFlag  (unsigned int flag)
@@ -363,6 +368,8 @@ public:
     bool HasWord(GridDirection dir) const;
 
     bool IsBetween(const Square * start, const Square * end) const;
+
+    Square* GetPartnerSquare() const { return m_partner; }
 protected:
     // Location information
     int m_col;
@@ -378,6 +385,9 @@ protected:
 
     // Flag (GEXT)
     unsigned int m_flag;
+
+    // Partner square (for Acrostics)
+    Square* m_partner = NULL;
 
     // Linked-list
     //------------

--- a/puz/Square.hpp
+++ b/puz/Square.hpp
@@ -51,6 +51,7 @@ enum GextFlag
     FLAG_MISSING   = 0x200, // No square
     FLAG_CORRECT   = 0x400, // Checked/correct
     FLAG_THEME     = 0x800, // A theme square
+    FLAG_CLUE      = 0x1000, // A clue square
 
     // Check square options
     FLAG_CHECK_MASK = FLAG_X |
@@ -187,12 +188,12 @@ public:
     // SetSolution(Square::Black) also calls SetText(Square::Black) for
     // consistency, so if your puzzle is diagramless, you will have to
     // explicitly call SetText("") on black squares to make them empty.
-    bool IsWhite()         const { return ! IsBlack() && ! IsMissing(); }
-    bool IsBlack()         const { return m_text == Black; }
+    bool IsWhite()         const { return !IsBlack() && !IsMissing(); }
+    bool IsBlack()         const { return m_text == Black || IsClue(); }
     bool IsBlank()         const { return m_text == Blank; }
     // Corresponding functions for the solution
-    bool IsSolutionWhite() const { return ! IsSolutionBlack() &&! IsMissing(); }
-    bool IsSolutionBlack() const { return m_solution == Black; }
+    bool IsSolutionWhite() const { return !IsSolutionBlack() && !IsMissing(); }
+    bool IsSolutionBlack() const { return m_solution == Black || IsClue(); }
     bool IsSolutionBlank() const { return m_solution == Blank; }
 
     // Text
@@ -284,6 +285,9 @@ public:
 
     bool IsTheme() const { return HasFlag(FLAG_THEME); }
     void SetTheme(bool doit = true) { AddFlag(FLAG_THEME, doit); }
+
+    bool IsClue() const { return HasFlag(FLAG_CLUE); }
+    void SetClue(bool doit = true) { AddFlag(FLAG_CLUE, doit); }
 
     bool HasColor() const { return HasFlag(FLAG_COLOR); }
     void SetColor(unsigned char red, unsigned char green, unsigned char blue);

--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -301,6 +301,10 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
         }
     }
 
+    if (grid.IsAcrostic()) {
+        grid.SetupIteration();
+    }
+
     // Words
     std::map<string_t, Word> words;
     {

--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -301,10 +301,6 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
         }
     }
 
-    if (grid.IsAcrostic()) {
-        grid.SetupIteration();
-    }
-
     // Words
     std::map<string_t, Word> words;
     {

--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -127,7 +127,12 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
 
     xml::SetInnerXML(puzzle.append_child("instructions"), puz->GetNotes());
 
-    xml::node crossword = puzzle.append_child("crossword");
+    const char* puzzle_root_tag;
+    if (grid.IsAcrostic())
+        puzzle_root_tag = "acrostic";
+    else
+        puzzle_root_tag = "crossword";
+    xml::node crossword = puzzle.append_child(puzzle_root_tag);
 
     // Grid
     xml::node xmlgrid = crossword.append_child("grid");
@@ -151,10 +156,12 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
             cell.append_attribute("y") = square->GetRow() + 1;
             if (square->IsMissing())
                 cell.append_attribute("type") = "void";
-            else if (square->IsBlack())
+            else if (square->IsBlack() && !square->IsClue())
                 cell.append_attribute("type") = "block";
             else
             {
+                if (square->IsClue())
+                    cell.append_attribute("type") = "clue";
                 cell.append_attribute("solution") =
                     encode_utf8(square->GetSolution()).c_str();
                 if (square->HasNumber())

--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -98,8 +98,11 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
 
         xml::node completion = settings.append_child("completion");
         completion.append_attribute("only-if-correct") = "true";
-        xml::SetText(completion, "Congratulations, you have solved the puzzle!");
-
+        string_t message = puz->GetMeta(puzT("completion"));
+        if (message.empty()) {
+            message = puzT("Congratulations, you have solved the puzzle!");
+        }
+        xml::SetText(completion, message);
     }
     // Timer
     applet.child("applet-settings").remove_child("timer");
@@ -203,7 +206,7 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
             if (! square->m_mark[MARK_TR].empty())
             {
                 cell.append_attribute("top-right-number") =
-                    encode_utf8(square->m_mark[MARK_TL]).c_str();
+                    encode_utf8(square->m_mark[MARK_TR]).c_str();
             }
             if (square->m_bars[BAR_TOP])
                 cell.append_attribute("top-bar") = "true";

--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -156,11 +156,11 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
             cell.append_attribute("y") = square->GetRow() + 1;
             if (square->IsMissing())
                 cell.append_attribute("type") = "void";
-            else if (square->IsBlack() && !square->IsClue())
+            else if (square->IsBlack() && !square->IsAnnotation())
                 cell.append_attribute("type") = "block";
             else
             {
-                if (square->IsClue())
+                if (square->IsAnnotation())
                     cell.append_attribute("type") = "clue";
                 cell.append_attribute("solution") =
                     encode_utf8(square->GetSolution()).c_str();

--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -1146,6 +1146,9 @@ MyFrame::CheckPuzzle()
             StopTimer();
             m_status->SetAlert(_T("The puzzle is filled correctly!"),
                 wxGetApp().GetConfigManager().Status.completeColor());
+            // Show completion message for acrostics since it is often the formatted quote.
+            if (m_puz.GetGrid().IsAcrostic() && m_puz.HasMeta(puzT("completion")))
+                XWordMessage(this, m_puz.GetMeta(puzT("completion")));
             break;
         case UNCHECKABLE_PUZZLE:
             StopTimer();

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -143,6 +143,8 @@ const int UNDEFINED_BOX_SIZE = -1;
 
 const char * MSG_NO_INCORRECT = "No Incorrect Letters!";
 
+wxColour EraseColor; // Sentinel used to erase a square's background
+
 // Helper functions for all of the "lookup" functions that return NULL
 inline void
 SetIfExists(puz::Square * &current, puz::Square * test)
@@ -553,7 +555,7 @@ XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & co
         m_drawer.RemoveFlag(XGridDrawer::DRAW_FLAG | XGridDrawer::DRAW_NUMBER);
     }
 
-    if (color == wxNullColour)
+    if (color == wxNullColour || &color == &EraseColor)
         m_drawer.DrawSquare(dc, square);
     else
         m_drawer.DrawSquare(dc, square, color, GetPenColor());
@@ -567,7 +569,10 @@ XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & co
 
     if (propagate && square.GetPartnerSquare()) {
         puz::Square* partner = square.GetPartnerSquare();
-        DrawSquare(dc, *partner, GetSquareColor(*partner), false);
+        if (&color == &EraseColor)
+            DrawSquare(dc, *partner, EraseColor, false);
+        else
+            DrawSquare(dc, *partner, GetSquareColor(*partner), false);
     }
 }
 
@@ -647,7 +652,7 @@ XGridCtrl::SetFocusedSquare(puz::Square * square,
     {
         puz::square_iterator it;
         for (it = oldWord->begin(); it != oldWord->end(); ++it)
-            DrawSquare(dc, *it, wxNullColour);
+            DrawSquare(dc, *it, EraseColor);
         oldWord = NULL;
     }
 
@@ -675,10 +680,10 @@ XGridCtrl::SetFocusedSquare(puz::Square * square,
             {
                 puz::square_iterator it;
                 for (it = oldWord->begin(); it != oldWord->end(); ++it)
-                    DrawSquare(dc, *it, wxNullColour);
+                    DrawSquare(dc, *it, EraseColor);
             }
             else if (oldSquare)
-                DrawSquare(dc, *oldSquare, wxNullColour);
+                DrawSquare(dc, *oldSquare, EraseColor);
 
             // Draw the new focused word
             if (m_focusedWord)

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -366,7 +366,7 @@ XGridCtrl::GetStats(GridStats * stats) const
         {
             ++stats->black;
         }
-        else
+        else if (!square->IsMissing())
         {
             ++stats->white;
             if (square->IsBlank())
@@ -533,7 +533,7 @@ XGridCtrl::DrawGrid(wxDC & dc, const wxRegion & updateRegion)
 
 
 void
-XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & color)
+XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & color, bool propagate)
 {
     // Don't draw missing squares
     if (square.IsMissing())
@@ -563,6 +563,11 @@ XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & co
     {
         m_drawer.RemoveFlag(XGridDrawer::DRAW_OUTLINE);
         m_drawer.AddFlag(XGridDrawer::DRAW_FLAG | XGridDrawer::DRAW_NUMBER);
+    }
+
+    if (propagate && square.GetPartnerSquare()) {
+        puz::Square* partner = square.GetPartnerSquare();
+        DrawSquare(dc, *partner, GetSquareColor(*partner), false);
     }
 }
 
@@ -1855,11 +1860,14 @@ const wxColor &
 XGridCtrl::GetSquareColor(const puz::Square & square)
 {
     if (HasSelection() && IsSelected(square))
-            return GetSelectionColor();
+        return GetSelectionColor();
     else if (IsFocusedLetter(square))
         return GetFocusedLetterColor();
     else if (IsFocusedWord(square))
         return GetFocusedWordColor();
+    else if (square.GetPartnerSquare() && IsFocusedLetter(*square.GetPartnerSquare())) {
+        return GetFocusedLetterColor();
+    }
     else
         return wxNullColour; // XGridDrawer will decide
 }

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -602,15 +602,22 @@ XGridCtrl::SetFocusedSquare(puz::Square * square,
         else if (! square->HasWord(static_cast<puz::GridDirection>(direction))
             && ! m_puz->FindWord(square, direction))
         {
-            puz::GridDirection newdir
-                = puz::IsVertical(direction) ? puz::ACROSS : puz::DOWN;
-            if (square->HasWord(newdir))
-                direction = newdir;
+            if (GetGrid()->IsAcrostic())
+            {
+                direction = puz::ACROSS;
+            }
             else
             {
-                word = m_puz->FindWord(square, newdir);
-                if (word)
+                puz::GridDirection newdir
+                    = puz::IsVertical(direction) ? puz::ACROSS : puz::DOWN;
+                if (square->HasWord(newdir))
                     direction = newdir;
+                else
+                {
+                    word = m_puz->FindWord(square, newdir);
+                    if (word)
+                        direction = newdir;
+                }
             }
         }
     }
@@ -1600,7 +1607,8 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
             // Check to see if there *should be* a (non-diagonal) word
             // in arrowDirection.
             if (! IsDiagonal(arrowDirection)
-                && m_focusedSquare->HasWord(arrowDirection))
+                && m_focusedSquare->HasWord(arrowDirection)
+                && !GetGrid()->IsAcrostic())
             {
                 SetFocusedSquare(m_focusedSquare, NULL, arrowDirection);
                 return;
@@ -1610,12 +1618,17 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
         if (! GetGrid()->IsDiagramless())
         {
             // Find the next white square in the arrow direction
+            puz::GridDirection newDirection;
+            if (GetGrid()->IsAcrostic())
+                newDirection = puz::ACROSS;
+            else
+                newDirection = arrowDirection;
             SetFocusedSquare(
                 m_grid->FindNextSquare(
                     m_focusedSquare, FIND_WHITE_SQUARE,
                     arrowDirection, puz::NO_WRAP
                 ),
-                NULL, arrowDirection
+                NULL, newDirection
             );
         }
         else // Diagramless

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -919,7 +919,7 @@ XGridCtrl::MakeVisible(const puz::Square & square)
 
 
 bool
-XGridCtrl::SetSquareText(puz::Square & square, const wxString & text, bool propagate)
+XGridCtrl::SetSquareText(puz::Square & square, const wxString & text)
 {
     // Are we allowed to enter this text?
     if (text == _T("."))
@@ -937,14 +937,6 @@ XGridCtrl::SetSquareText(puz::Square & square, const wxString & text, bool propa
     // Not allowed to overwrite revealed letters or checked letters
     if (square.HasFlag(puz::FLAG_REVEALED | puz::FLAG_CORRECT))
         return false;
-
-    if (GetGrid()->IsAcrostic() && propagate) {
-        // Propagate the text to the partner square in the Acrostic.
-        puz::Square* partnerSquare = GetPartnerSquare(square);
-        if (partnerSquare) {
-            SetSquareText(*partnerSquare, text, /* propagate= */ false);
-        }
-    }
 
     // renumber the grid if the square is changing from black to white or vice-versa
     const bool numberGrid = GetGrid()->IsDiagramless() &&
@@ -980,23 +972,7 @@ XGridCtrl::SetSquareText(puz::Square & square, const wxString & text, bool propa
     return true;
 }
 
-puz::Square*
-XGridCtrl::GetPartnerSquare(const puz::Square& square) {
-    wxASSERT(GetGrid()->IsAcrostic());
-    // TODO: Should we precalculate the partner squares to make this a faster lookup?
-    for (size_t y = 0; y < GetGrid()->GetHeight(); y++) {
-        for (size_t x = 0; x < GetGrid()->GetWidth(); x++) {
-            if (x != square.GetCol() || y != square.GetRow()) {
-                puz::Square* sq = GetGrid()->AtNULL(x, y);
-                if (sq->IsWhite() && square.GetNumber() == sq->GetNumber()) {
-                    return sq;
-                }
-            }
-        }
-    }
-    wxFAIL;
-    return NULL;
-}
+
 
 void
 XGridCtrl::StartSelection(wxObjectEventFunction func, wxEvtHandler * evtSink)
@@ -1176,52 +1152,30 @@ XGridCtrl::CheckSquare(puz::Square * square, int options, wxDC & dc)
 {
     if (! square->IsWhite() && ! m_puz->IsDiagramless())
         return true;
-    RemoveSquareFlag(*square, puz::FLAG_CORRECT);
+    square->RemoveFlag(puz::FLAG_CORRECT);
     if (! square->Check((options & CHECK_ALL) != 0, HasStyle(STRICT_REBUS)))
     {
         if ( (options & REVEAL_ANSWER) != 0)
         {
             SetSquareText(*square, puz2wx(square->GetSolution()));
-            RemoveSquareFlag(*square, puz::FLAG_BLACK | puz::FLAG_X);
-            AddSquareFlag(*square, puz::FLAG_REVEALED);
+            square->RemoveFlag(puz::FLAG_BLACK | puz::FLAG_X);
+            square->AddFlag(puz::FLAG_REVEALED);
         }
         else
         {
-            RemoveSquareFlag(*square, puz::FLAG_BLACK);
-            AddSquareFlag(*square, puz::FLAG_X);
+            square->RemoveFlag(puz::FLAG_BLACK);
+            square->AddFlag(puz::FLAG_X);
         }
         RefreshSquare(dc, *square);
         return false;
     }
     else if (! square->IsBlank() && ! square->HasFlag(puz::FLAG_REVEALED))
     {
-        AddSquareFlag(*square, puz::FLAG_CORRECT);
+        square->AddFlag(puz::FLAG_CORRECT);
         RefreshSquare(dc, *square);
         return true;
     }
     return true;
-}
-
-void
-XGridCtrl::AddSquareFlag(puz::Square& square, unsigned int flag, bool propagate) {
-    square.AddFlag(flag);
-    if (GetGrid()->IsAcrostic() && propagate) {
-        puz::Square* partnerSquare = GetPartnerSquare(square);
-        if (partnerSquare) {
-            AddSquareFlag(*partnerSquare, flag, /* propagate= */ false);
-        }
-    }
-}
-
-void
-XGridCtrl::RemoveSquareFlag(puz::Square& square, unsigned int flag, bool propagate) {
-    square.RemoveFlag(flag);
-    if (GetGrid()->IsAcrostic() && propagate) {
-        puz::Square* partnerSquare = GetPartnerSquare(square);
-        if (partnerSquare) {
-            RemoveSquareFlag(*partnerSquare, flag, /* propagate= */ false);
-        }
-    }
 }
 
 

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -194,13 +194,11 @@ public:
         { SetFocusedSquare(NULL, direction); }
 
     // Drawing functions
-    void RefreshSquare(wxDC & dc, const puz::Square & square)  { 
-        DrawSquare(dc, square); 
-        if (GetGrid()->IsAcrostic()) {
-            puz::Square* partnerSquare = GetPartnerSquare(square);
-            if (partnerSquare) {
-                DrawSquare(dc, *partnerSquare);
-            }
+    void RefreshSquare(wxDC & dc, const puz::Square & square)  {
+        DrawSquare(dc, square);
+        puz::Square* partnerSquare = square.GetPartnerSquare();
+        if (partnerSquare) {
+            DrawSquare(dc, *partnerSquare);
         }
     }
     void RefreshSquare(const puz::Square & square)
@@ -217,7 +215,7 @@ public:
             DrawSquare(dc, *it);
     }
 
-    bool SetSquareText(puz::Square & square, const wxString & text = _T(""), bool propagate = true);
+    bool SetSquareText(puz::Square & square, const wxString & text = _T(""));
 
     const puz::Square * GetFocusedSquare() const { return m_focusedSquare; }
           puz::Square * GetFocusedSquare()       { return m_focusedSquare; }
@@ -424,14 +422,6 @@ protected:
     XGridRebusCtrl * m_rebusCtrl;
 
 private:
-    void AddSquareFlag(puz::Square& square, unsigned int flag, bool propagate = true);
-    void RemoveSquareFlag(puz::Square& square, unsigned int flag, bool propagate = true);
-
-    // For Acrostic puzzles, return the partner square for the given square.
-    // This is the square with the same number - from the quote if the given square
-    // is from a clue, or vice versa.
-    puz::Square* GetPartnerSquare(const puz::Square& square);
-
     // Events
     bool m_areEventsConnected;
 

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -368,7 +368,7 @@ protected:
     void DrawPauseMessage(wxDC & dc);
     void DrawGrid(wxDC & dc, const wxRegion & updateRegion = wxRegion());
 
-    void DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & color);
+    void DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & color, bool propagate = true);
 
     void DrawSquare(wxDC & dc, const puz::Square & square)
         { DrawSquare(dc, square, GetSquareColor(square)); }

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -194,7 +194,15 @@ public:
         { SetFocusedSquare(NULL, direction); }
 
     // Drawing functions
-    void RefreshSquare(wxDC & dc, const puz::Square & square)  { DrawSquare(dc, square); }
+    void RefreshSquare(wxDC & dc, const puz::Square & square)  { 
+        DrawSquare(dc, square); 
+        if (GetGrid()->IsAcrostic()) {
+            puz::Square* partnerSquare = GetPartnerSquare(square);
+            if (partnerSquare) {
+                DrawSquare(dc, *partnerSquare);
+            }
+        }
+    }
     void RefreshSquare(const puz::Square & square)
         { wxClientDC dc(this); DoPrepareDC(dc); RefreshSquare(dc, square); }
 
@@ -209,7 +217,7 @@ public:
             DrawSquare(dc, *it);
     }
 
-    bool SetSquareText(puz::Square & square, const wxString & text = _T(""));
+    bool SetSquareText(puz::Square & square, const wxString & text = _T(""), bool propagate = true);
 
     const puz::Square * GetFocusedSquare() const { return m_focusedSquare; }
           puz::Square * GetFocusedSquare()       { return m_focusedSquare; }
@@ -416,6 +424,14 @@ protected:
     XGridRebusCtrl * m_rebusCtrl;
 
 private:
+    void AddSquareFlag(puz::Square& square, unsigned int flag, bool propagate = true);
+    void RemoveSquareFlag(puz::Square& square, unsigned int flag, bool propagate = true);
+
+    // For Acrostic puzzles, return the partner square for the given square.
+    // This is the square with the same number - from the quote if the given square
+    // is from a clue, or vice versa.
+    puz::Square* GetPartnerSquare(const puz::Square& square);
+
     // Events
     bool m_areEventsConnected;
 

--- a/src/XGridCtrl.hpp
+++ b/src/XGridCtrl.hpp
@@ -194,13 +194,7 @@ public:
         { SetFocusedSquare(NULL, direction); }
 
     // Drawing functions
-    void RefreshSquare(wxDC & dc, const puz::Square & square)  {
-        DrawSquare(dc, square);
-        puz::Square* partnerSquare = square.GetPartnerSquare();
-        if (partnerSquare) {
-            DrawSquare(dc, *partnerSquare);
-        }
-    }
+    void RefreshSquare(wxDC & dc, const puz::Square & square)  { DrawSquare(dc, square); }
     void RefreshSquare(const puz::Square & square)
         { wxClientDC dc(this); DoPrepareDC(dc); RefreshSquare(dc, square); }
 

--- a/src/XGridDrawer.cpp
+++ b/src/XGridDrawer.cpp
@@ -518,7 +518,7 @@ XGridDrawer::DrawSquare(wxDC & adc,
         dc.DrawRectangle(x, y, m_boxSize, m_boxSize);
     }
 
-    if ((HasFlag(DRAW_SOLUTION) ? square.IsSolutionBlack() : square.IsBlack()) && !square.IsClue())
+    if ((HasFlag(DRAW_SOLUTION) ? square.IsSolutionBlack() : square.IsBlack()) && !square.IsAnnotation())
         return; // Nothing else to do if it's a black square.
 
     // Draw square's flag (top right)

--- a/src/XGridDrawer.cpp
+++ b/src/XGridDrawer.cpp
@@ -518,7 +518,7 @@ XGridDrawer::DrawSquare(wxDC & adc,
         dc.DrawRectangle(x, y, m_boxSize, m_boxSize);
     }
 
-    if (HasFlag(DRAW_SOLUTION) ? square.IsSolutionBlack() : square.IsBlack())
+    if ((HasFlag(DRAW_SOLUTION) ? square.IsSolutionBlack() : square.IsBlack()) && !square.IsClue())
         return; // Nothing else to do if it's a black square.
 
     // Draw square's flag (top right)
@@ -561,7 +561,7 @@ XGridDrawer::DrawSquare(wxDC & adc,
         dc.SetTextForeground(textColor);
 
         // Draw corner marks
-        wxRect markRect(x+1, y+1, m_boxSize - 2, m_boxSize - 2);
+        wxRect markRect(x+1, y, m_boxSize - 2, m_boxSize - 2);
         if (! square.m_mark[puz::MARK_TL].empty())
             dc.DrawLabel(puz2wx(square.m_mark[puz::MARK_TL]), markRect,
                          wxALIGN_TOP | wxALIGN_LEFT);


### PR DESCRIPTION
This is a new extension to JPZ files being used by Outside the Box
puzzles and supported by the Crossword Nexus solver. It mostly follows
the JPZ standard, but uses the `<acrostic>` root XML tag instead of
`<crossword>` and requires that entries be propagated to their partner
squares with the same number.

This commit adds support for the new "Acrostic" grid type, enabling
loads/saves from the JPZ format. "clue" type squares are now supported -
these are used for the letters of each clue as well as punctuation in
the quote. Changes made to square contents (letters/flags) are
propagated to partner squares. The top-right text is changed to align
precisely with the clue number, as it was a pixel off before.

The primary remaining pieces for parity with Crossword Nexus are:

1.  Fixed navigation. The unconventional grid structure leads to strange
    arrow key and mouse click behavior when navigating through the grid.
    Navigation should consistently stay in the (only) Across direction
    and just move to the nearest square in that direction, switching
    words to the (only) word for that square if the word changes.

2.  Optionally, showing the completion message upon finishing the puzzle
    correctly, since for Acrostics this will generally include the fully
    formatted quote and author.