### PR TITLE
Clean up HTML when setting window title.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -18,6 +18,7 @@
 #include "MyFrame.hpp"
 #include "paths.hpp"
 #include "messages.hpp"
+#include "html/parse.hpp"
 
 // For the global printing pointers and application activation / timer starting
 // and stopping.
@@ -975,8 +976,12 @@ MyFrame::ShowMetadata()
     // Set window title
     if (! m_puz.IsOk())
         SetTitle(XWORD_APP_NAME);
-    else
-        SetTitle(puz2wx(m_puz.GetTitle()) + _T(" - ") XWORD_APP_NAME);
+    else {
+        // Puzzle titles can contain HTML, so parse out the plain text.
+        PlainTextHtmlParser parser;
+        wxString title = * (wxString*) (parser.Parse(puz2wx(m_puz.GetTitle())));
+        SetTitle(title + _T(" - ") XWORD_APP_NAME);
+    }
 
     // Update the metadata panels
     typedef std::vector<wxAuiPaneInfo *> pane_vector_t;

--- a/src/html/parse.hpp
+++ b/src/html/parse.hpp
@@ -34,3 +34,22 @@ public:
 
     virtual void InitParser(const wxString& source);
 };
+
+// Simple HTML parser which just combines all text and returns it.
+class PlainTextHtmlParser : public wxHtmlParser
+{
+public:
+    virtual void AddTag(const wxHtmlTag& tag) {
+        if (tag.HasEnding())
+            DoParsing(tag.GetBeginIter(), tag.GetEndIter1());
+    }
+    virtual void AddText(const wxString& txt) {
+        text.append(txt);
+    }
+    virtual wxObject* GetProduct() {
+        return (wxObject*) &text;
+    }
+
+private:
+    wxString text;
+};


### PR DESCRIPTION
Puzzle metadata, including titles, can include HTML, which isn't
supported by the window title bar. So we parse the title as HTML,
ignoring all style tags and just combining the text into a flat
string, before setting the title.

Resolves `&amp;` showing up in the title rather than `&`.

See #117