### PR TITLE
Add support for coded crosswords (aka "codewords").

### DIFF
--- a/lua/luapuz/bind/luapuz_puz.cpp
+++ b/lua/luapuz/bind/luapuz_puz.cpp
@@ -184,6 +184,7 @@ const luapuz_enumReg GridType_reg[] = {
     {"TYPE_NORMAL", puz::TYPE_NORMAL},
     {"TYPE_DIAGRAMLESS", puz::TYPE_DIAGRAMLESS},
     {"TYPE_ACROSTIC", puz::TYPE_ACROSTIC},
+    {"TYPE_CODED", puz::TYPE_CODED},
     {NULL, NULL}
 };
 

--- a/lua/luapuz/bind/luapuz_puz_Grid.cpp
+++ b/lua/luapuz/bind/luapuz_puz_Grid.cpp
@@ -296,6 +296,14 @@ static int Grid_IsAcrostic(lua_State * L)
     lua_pushboolean(L, returns);
     return 1;
 }
+// bool IsCoded()
+static int Grid_IsCoded(lua_State * L)
+{
+    puz::Grid * grid = luapuz_checkGrid(L, 1);
+    bool returns = grid->IsCoded();
+    lua_pushboolean(L, returns);
+    return 1;
+}
 // unsigned short GetType()
 static int Grid_GetType(lua_State * L)
 {
@@ -484,6 +492,7 @@ static const luaL_reg Gridlib[] = {
     {"SetFlag", Grid_SetFlag},
     {"IsDiagramless", Grid_IsDiagramless},
     {"IsAcrostic", Grid_IsAcrostic},
+    {"IsCoded", Grid_IsCoded},
     {"GetType", Grid_GetType},
     {"SetType", Grid_SetType},
     {"ScrambleSolution", Grid_ScrambleSolution},

--- a/lua/luapuz/bind/puz_defs.lua
+++ b/lua/luapuz/bind/puz_defs.lua
@@ -71,6 +71,7 @@ enum { "GridType", header="puz/Grid.hpp",
     "TYPE_NORMAL",
     "TYPE_DIAGRAMLESS",
     "TYPE_ACROSTIC",
+    "TYPE_CODED",
 }
 
 enum { "FindOptions", header="puz/Grid.hpp",
@@ -231,6 +232,7 @@ class{"Grid", header="puz/Grid.hpp"}
 
     func{"IsDiagramless", returns="bool"}
     func{"IsAcrostic", returns="bool"}
+    func{"IsCoded", returns="bool"}
     property{"unsigned short", "Type"}
 
     func{"ScrambleSolution", returns="bool", arg("unsigned short", "key", "0")}

--- a/puz/Grid.cpp
+++ b/puz/Grid.cpp
@@ -274,23 +274,21 @@ void Grid::NumberGrid()
 void
 Grid::FindPartnerSquares()
 {
-    if (!IsAcrostic()) return;
-    std::map<string_t, Square*> partner_map;
+    if (!IsAcrostic() && !IsCoded()) return;
+    std::multimap<string_t, Square*> partner_map;
     for (size_t row = 0; row < GetHeight(); ++row)
     {
         for (size_t col = 0; col < GetWidth(); ++col)
         {
             Square& square = At(col, row);
             if (square.HasNumber()) {
-                std::map<string_t, Square*>::iterator it = partner_map.find(square.GetNumber());
-                if (it == partner_map.end()) {
-                    partner_map[square.GetNumber()] = &square;
+                typedef std::multimap<string_t, Square*>::iterator PartnerIterator;
+                std::pair<PartnerIterator, PartnerIterator> result = partner_map.equal_range(square.GetNumber());
+                for (PartnerIterator it = result.first; it != result.second; ++it) {
+                    (*it).second->m_partner.push_back(&square);
+                    square.m_partner.push_back((*it).second);
                 }
-                else {
-                    Square* partner = it->second;
-                    square.m_partner = partner;
-                    partner->m_partner = &square;
-                }
+                partner_map.insert(std::make_pair(square.GetNumber(), &square));
             }
         }
     }

--- a/puz/Grid.hpp
+++ b/puz/Grid.hpp
@@ -43,6 +43,7 @@ enum GridType
     TYPE_DIAGRAMLESS = 0x0401,
     // Additional flags
     TYPE_ACROSTIC    = 0x1000,
+    TYPE_CODED       = 0x2000,
 };
 
 // Parameters for FindSquare
@@ -193,6 +194,7 @@ public:
     // Type
     bool IsDiagramless() const { return m_type == TYPE_DIAGRAMLESS; }
     bool IsAcrostic() const { return m_type == TYPE_ACROSTIC; }
+    bool IsCoded() const { return m_type == TYPE_CODED; }
     unsigned short GetType() const { return m_type; }
     void SetType(unsigned short type) { m_type = type; }
 

--- a/puz/Square.cpp
+++ b/puz/Square.cpp
@@ -392,8 +392,9 @@ void Square::SetText(const string_t & text, bool propagate)
         m_text = text;
     else
         m_text = ToGrid(text);
-    if (propagate && m_partner != NULL) {
-        m_partner->SetText(text, false);
+    if (propagate && !m_partner.empty()) {
+        for (std::vector<Square*>::iterator it = m_partner.begin(); it != m_partner.end(); ++it)
+            (*it)->SetText(text, false);
     }
 }
 

--- a/puz/Square.hpp
+++ b/puz/Square.hpp
@@ -21,6 +21,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <vector>
 #include "puzstring.hpp"
 #include "exceptions.hpp"
 
@@ -264,8 +265,9 @@ public:
     //------
     void         SetFlag (unsigned int flag, bool propagate = true) {
         m_flag = flag;
-        if (propagate && m_partner) {
-            m_partner->SetFlag(flag, false);
+        if (propagate && !m_partner.empty()) {
+            for (std::vector<Square*>::iterator it = m_partner.begin(); it != m_partner.end(); ++it)
+                (*it)->SetFlag(flag, false);
         }
     }
     unsigned int GetFlag() const             { return m_flag; }
@@ -369,7 +371,7 @@ public:
 
     bool IsBetween(const Square * start, const Square * end) const;
 
-    Square* GetPartnerSquare() const { return m_partner; }
+    std::vector<Square*> GetPartnerSquares() const { return m_partner; }
 protected:
     // Location information
     int m_col;
@@ -386,8 +388,8 @@ protected:
     // Flag (GEXT)
     unsigned int m_flag;
 
-    // Partner square (for Acrostics)
-    Square* m_partner = NULL;
+    // Partner squares (for Acrostics and Coded puzzles)
+    std::vector<Square*> m_partner;
 
     // Linked-list
     //------------

--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -172,10 +172,17 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
     if (! crossword)
     {
         crossword = puzzle.child("acrostic");
-        if (!crossword)
-            throw FileTypeError("jpz must have either <crossword> or <acrostic> tag");
-        grid.SetType(TYPE_ACROSTIC);
+        if (crossword)
+            grid.SetType(TYPE_ACROSTIC);
     }
+    if (! crossword)
+    {
+        crossword = puzzle.child("coded");
+        if (crossword)
+            grid.SetType(TYPE_CODED);
+    }
+    if (! crossword)
+        throw FileTypeError("jpz does not contain a supported puzzle type");
 
     // Metadata
     xml::node meta = puzzle.child("metadata");
@@ -377,7 +384,7 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
             hasClueList = true;
         }
 
-        if (!hasClueList) {
+        if (!hasClueList && !grid.IsCoded()) {
             throw LoadError("Must have at least one clue list");
         }
     }

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -482,7 +482,7 @@ XGridCtrl::DrawGrid(wxDC & dc, const wxRegion & updateRegion)
     // If we don't have an update region, redraw all squares
     if (updateRegion.IsEmpty())
         for (square = m_grid->First(); square != NULL; square = square->Next())
-            DrawSquare(dc, *square);
+            DrawSquare(dc, *square, GetSquareColor(*square), /* propagate= */ false);
 
     // If we do have an update region, redraw all squares within the region
     else
@@ -567,12 +567,15 @@ XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & co
         m_drawer.AddFlag(XGridDrawer::DRAW_FLAG | XGridDrawer::DRAW_NUMBER);
     }
 
-    if (propagate && square.GetPartnerSquare()) {
-        puz::Square* partner = square.GetPartnerSquare();
-        if (&color == &EraseColor)
-            DrawSquare(dc, *partner, EraseColor, false);
-        else
-            DrawSquare(dc, *partner, GetSquareColor(*partner), false);
+    if (propagate && !square.GetPartnerSquares().empty()) {
+        std::vector<puz::Square*> partners = square.GetPartnerSquares();
+        for (std::vector<puz::Square*>::iterator it = partners.begin(); it != partners.end(); ++it) {
+            puz::Square* partner = *it;
+            if (&color == &EraseColor)
+                DrawSquare(dc, *partner, EraseColor, false);
+            else
+                DrawSquare(dc, *partner, GetSquareColor(*partner), false);
+        }
     }
 }
 
@@ -1870,11 +1873,14 @@ XGridCtrl::GetSquareColor(const puz::Square & square)
         return GetFocusedLetterColor();
     else if (IsFocusedWord(square))
         return GetFocusedWordColor();
-    else if (square.GetPartnerSquare() && IsFocusedLetter(*square.GetPartnerSquare())) {
-        return GetFocusedLetterColor();
+    else if (!square.GetPartnerSquares().empty()) {
+        std::vector<puz::Square*> partners = square.GetPartnerSquares();
+        for (std::vector<puz::Square*>::iterator it = partners.begin(); it != partners.end(); ++it) {
+            if (IsFocusedLetter(*(*it)))
+                return GetFocusedLetterColor();
+        }
     }
-    else
-        return wxNullColour; // XGridDrawer will decide
+    return wxNullColour; // XGridDrawer will decide
 }
 
 


### PR DESCRIPTION
Coded crosswords have no clues; instead, each square is numbered from
1-26, and each number represents a particular letter to be determined.
All squares with the same number contain the same letter.

Supporting these puzzles is quite similar to Acrostics in that we can
consider all the squares with the same number to be "partners" and
propagate changes to one square to all partner squares. We extend the
partner concept to support multiple partner squares instead of just one.

This provides a functional interface, but there are some drawbacks:

-  The cluelists still appear (Across/Down) despite being empty.
   Crossword Solver hides the unnecessary cluelist for this puzzle type.

-  The rendering performance is quite slow, probably because there are
   so many partner squares to update each time the cursor moves.

-  Crossword Solver shows a helpful letter bank indicating which letters
   have been used and which ones are remaining; this is missing from
   XWord.