### PR TITLE
Speed up brute force unscramble on Windows.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -3214,10 +3214,10 @@ MyFrame::OnBruteForceUnscramble(wxCommandEvent & WXUNUSED(evt))
     dlg->StartTimer();
     for (unsigned short i = 1000; i <= 9999; ++i)
     {
-        wxTheApp->Yield(); // Don't block the GUI.
         // Only update every 100 keys so rendering doesn't slow down the unscramble process.
         if (i % 100 == 0) {
             dlg->SetKey(i);
+            wxTheApp->Yield(); // Don't block the GUI.
         }
         std::string solution = scrambler.GetUnscrambledSolution(i);
         if (!solution.empty())


### PR DESCRIPTION
Most of the time is spent yielding, so yield every 100 keys instead of
every key attempted. This is for debugging anyway, so high UI
responsivity isn't particularly critical.