### PR TITLE
Refine selection of initial square.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -826,8 +826,6 @@ MyFrame::ShowGrid()
         const bool can_check = scrambled || ! m_puz.GetGrid().HasSolution();
         EnableCheck(! can_check);
         EnableReveal(! can_check);
-
-        m_XGridCtrl->SetFocusedSquare(m_XGridCtrl->FirstWhite());
     }
 
     m_XGridCtrl->SetPaused(false);


### PR DESCRIPTION
Previously, we focused on the first white square and an arbitrary word
in the Across direction containing that square.

Now, if there is either exactly one clue list, or a clue list labeled
"Across", we focus on the first square of the first word in that list.
Otherwise, we fall back to the same logic as before.

See #134 