### PR TITLE
Respect clue list ordering from file and expand initial clue selection.

### DIFF
--- a/puz/Clue.cpp
+++ b/puz/Clue.cpp
@@ -184,9 +184,27 @@ bool Clues::HasWords() const
 ClueList & Clues::operator[](const string_t & direction)
 {
     iterator it = find(direction);
-    if (it == end())
-        return insert(std::make_pair(direction, ClueList(direction))).first->second;
+    if (it == end()) {
+        push_back(std::make_pair(direction, ClueList(direction)));
+        return back().second;
+    }
     return it->second;
+}
+
+std::vector<std::pair<string_t, ClueList> >::iterator Clues::find(const string_t& direction) {
+    std::vector<std::pair<string_t, ClueList> >::iterator it = begin();
+    while (it != end() && it->first != direction) {
+        it++;
+    }
+    return it;
+}
+
+std::vector<std::pair<string_t, ClueList> >::const_iterator Clues::find(const string_t& direction) const {
+    std::vector<std::pair<string_t, ClueList> >::const_iterator it = begin();
+    while (it != end() && it->first != direction) {
+        it++;
+    }
+    return it;
 }
 
 } // namespace puz

--- a/puz/Clue.hpp
+++ b/puz/Clue.hpp
@@ -127,7 +127,7 @@ protected:
 
 
 // This class holds all of the clues
-class PUZ_API Clues : public std::map<string_t, ClueList>
+class PUZ_API Clues : public std::vector<std::pair<string_t, ClueList> >
 {
 public:
     Clues() {}
@@ -153,6 +153,9 @@ public:
             ret.SetTitle(direction);
         return ret;
     }
+
+    std::vector<std::pair<string_t, ClueList> >::iterator find(const string_t& direction);
+    std::vector<std::pair<string_t, ClueList> >::const_iterator find(const string_t& direction) const;
 };
 
 } // namespace puz

--- a/puz/Puzzle.cpp
+++ b/puz/Puzzle.cpp
@@ -182,8 +182,8 @@ void Puzzle::SetAllClues(const std::vector<string_t> & clues)
 {
     NumberGrid();
 
-    ClueList & across = SetClueList(puzT("Across"), ClueList());
-    ClueList & down   = SetClueList(puzT("Down"), ClueList());
+    ClueList across = ClueList();
+    ClueList down   = ClueList();
 
     std::vector<string_t>::const_iterator clue_it = clues.begin();
     std::vector<string_t>::const_iterator clue_end = clues.end();
@@ -219,6 +219,9 @@ void Puzzle::SetAllClues(const std::vector<string_t> & clues)
         if (wantsAcross || wantsDown)
             ++clueNumber;
     }
+
+    SetClueList(puzT("Across"), across);
+    SetClueList(puzT("Down"), down);
 
     if (clue_it != clue_end)
         throw InvalidClues();

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -281,13 +281,14 @@ XGridCtrl::SetPuzzle(puz::Puzzle * puz)
         puz::Clues* clues = &puz->GetClues();
         puz::ClueList* firstClueList = NULL;
         if (!m_grid->IsDiagramless()) {
-            if (clues->size() == 1) {
-                // If there's only one list, use that.
-                firstClueList = &clues->begin()->second;
-            }
-            else if (clues->find(puzT("Across")) != clues->end()) {
+            if (clues->find(puzT("Across")) != clues->end()) {
                 // If there's an "Across" list, use that.
                 firstClueList = &clues->GetAcross();
+            }
+            else if (!clues->empty()) {
+                // Select the first clue list - assumes that the file is likely in the intended
+                // clue list order (and that this order is retained when reading the file).
+                firstClueList = &clues->begin()->second;
             }
         }
 


### PR DESCRIPTION
Change Clues from a map, which is ordered alphabetically, to a vector,
which retains insertion order. This should make no difference for
regular crosswords (and there is special logic to handle Across/Down
even if out of order), but retains the order from variety puzzle formats
which is more likely to be the intended viewing order.

Also expand the logic used to select the initial clue; previously, we
only selected the first clue's first square if there was one clue list.
We now do this even if there is more than one clue list. This is more
likely to be reasonable now that clue list ordering is maintained from
the original file.

Fixes #134