### PR TITLE
Improve handling of different capitalizations of "Across" and "Down".

### DIFF
--- a/puz/Clue.hpp
+++ b/puz/Clue.hpp
@@ -147,8 +147,18 @@ public:
 
     ClueList & SetClueList(const string_t & direction, const ClueList & cluelist)
     {
-        operator[](direction) = cluelist;
-        ClueList & ret = operator[](direction);
+        // Normalize different capitalizations of "Across" and "Down", since these have special meaning.
+        // We still retain the original direction in the title field.
+        string_t canonical_direction;
+        if (CaseInsensitiveEquals(direction, puzT("Across")))
+            canonical_direction = puzT("Across");
+        else if (CaseInsensitiveEquals(direction, puzT("Down")))
+            canonical_direction = puzT("Down");
+        else
+            canonical_direction = direction;
+
+        operator[](canonical_direction) = cluelist;
+        ClueList & ret = operator[](canonical_direction);
         if (ret.GetTitle().empty())
             ret.SetTitle(direction);
         return ret;

--- a/puz/puzstring.cpp
+++ b/puz/puzstring.cpp
@@ -318,6 +318,21 @@ bool EndsWith(const string_t & str, const string_t & cmp)
            str.compare(str.size() - cmp.size(), cmp.size(), cmp) == 0;
 }
 
+bool CaseInsensitiveEquals(const string_t& a, const string_t& b)
+{
+    unsigned int sz = a.size();
+    if (b.size() != sz)
+        return false;
+    for (unsigned int i = 0; i < sz; ++i)
+#if PUZ_UNICODE
+        if (towlower(a[i]) != towlower(b[i]))
+#else
+        if (tolower(a[i]) != tolower(b[i]))
+#endif
+            return false;
+    return true;
+}
+
 //----------------------------------------------------------------------------
 // Convert between formatted / unformatted
 //----------------------------------------------------------------------------

--- a/puz/puzstring.hpp
+++ b/puz/puzstring.hpp
@@ -84,6 +84,8 @@ int ToInt(const string_t & str);
 bool StartsWith(const string_t & str, const string_t & cmp);
 bool EndsWith(const string_t & str, const string_t & cmp);
 
+bool CaseInsensitiveEquals(const string_t& a, const string_t& b);
+
 // XML stuff
 enum {
     UNESCAPE_BR = 1,


### PR DESCRIPTION
When setting a ClueList, normalize them to the canonical "Across" and
"Down" as is used elsewhere in XWord. This fixes features like reuse of
existing settings for the Across and Down clue panes and saving the file
as an Across Lite .puz file.

Note that this results in the displayed clue list using the canonical
name and not the provided name, since MyFrame::ShowClues is built around
using the keys and not the titles. However, this is only a minor
cosmetic difference that seems harder to fix.

See #140 