### PR TITLE
Propagate puzzle notes to PUZ files in the notepad.

### DIFF
--- a/puz/Checksummer.cpp
+++ b/puz/Checksummer.cpp
@@ -53,9 +53,30 @@ Checksummer::Checksummer(const Puzzle & puz, unsigned short version)
     : m_title    (encode_puz(puz.GetTitle())),
       m_author   (encode_puz(puz.GetAuthor())),
       m_copyright(encode_puz(puz.GetCopyright())),
-      m_notes    (GetPuzText(puz.GetNotes())),
       m_version  (version)
 {
+    // Notes
+    // Since puz doesn't support metadata, we store all notes-like fields in the single supported
+    // notes field, in the format:
+    // [Header, in title case]:[trailing space]
+    // [Contents]
+    // with a blank line separating each section. If there is only one section, the header is
+    // omitted.
+    // The colon and trailing space improve rendering in regular Across Lite, which doesn't
+    // render newlines.
+    const std::vector<std::pair<puz::string_t, puz::string_t> >& all_notes = puz.GetAllNotes();
+    std::vector<std::pair<puz::string_t, puz::string_t> >::const_iterator it;
+    for (it = all_notes.begin(); it != all_notes.end(); ++it)
+    {
+        if (it != all_notes.begin()) {
+            m_notes.append(" \n\n");
+        }
+        if (all_notes.size() > 1) {
+            m_notes.append(GetPuzText(TitleCase(it->first)) + ": \n");
+        }
+        m_notes.append(GetPuzText(it->second));
+    }
+
     // Solution and Text
     m_solution.reserve(puz.GetGrid().GetWidth() * puz.GetGrid().GetHeight());
     m_gridText.reserve(puz.GetGrid().GetWidth() * puz.GetGrid().GetHeight());

--- a/puz/Puzzle.cpp
+++ b/puz/Puzzle.cpp
@@ -353,6 +353,49 @@ void Puzzle::MarkThemeSquares()
     }
 }
 
+// Should this metadata be displayed as notes?
+// Either has "_notes_" in the name, or is one of
+// "description", or "instructions"
+bool IsNotes(const puz::string_t& str)
+{
+    // str == "notes" is the real notepad
+    // Starts with "notes_"
+    if (str.compare(0, 6, puzT("notes_")) == 0)
+        return true;
+    // Ends with "_notes"
+    int start = str.length() - 6;
+    if (start >= 0 && str.compare(start, puz::string_t::npos, puzT("_notes")) == 0)
+        return true;
+    // Contains "-notes-"
+    if (str.find(puzT("_notes_")) != puz::string_t::npos)
+        return true;
+    // description/instructions
+    if (str == puzT("description") || str == puzT("instructions"))
+        return true;
+    return false;
+}
+
+const std::vector<std::pair<string_t, string_t> >
+Puzzle::GetAllNotes() const
+{
+    std::vector<std::pair<string_t, string_t> > all_notes;
+    // First, include the regular notes, if any.
+    const string_t& notes = GetNotes();
+    if (!notes.empty())
+        all_notes.push_back(std::make_pair(puzT("notes"), notes));
+
+    // Then, include any other notes-like metadata.
+    const puz::Puzzle::metamap_t& meta = GetMetadata();
+    puz::Puzzle::metamap_t::const_iterator it;
+    for (it = meta.begin(); it != meta.end(); ++it)
+    {
+        if (IsNotes(it->first))
+            all_notes.push_back(std::make_pair(it->first, it->second));
+    }
+
+    return all_notes;
+}
+
 //------------------------------------------------------------------------------
 // Find functions
 //------------------------------------------------------------------------------

--- a/puz/Puzzle.hpp
+++ b/puz/Puzzle.hpp
@@ -114,6 +114,9 @@ public:
     const string_t & GetNotes() const { return GetMeta(puzT("notes")); }
     void SetNotes(const string_t & notes) { SetMeta(puzT("notes"), notes); }
 
+    // Get a vector of all notes-like metadata for display.
+    const std::vector<std::pair<string_t, string_t> > GetAllNotes() const;
+
     // Words
     const Word * FindWord(const puz::Square * square) const;
           Word * FindWord(const puz::Square * square);

--- a/puz/formats/puz/save_puz.cpp
+++ b/puz/formats/puz/save_puz.cpp
@@ -112,7 +112,6 @@ void SavePuz(Puzzle * puz, const std::string & filename, void * /* dummy */)
 
 
 static void WriteGEXT(Puzzle * puz, ostream_wrapper & f);
-static void WriteMETA(Puzzle * puz, ostream_wrapper & f);
 static void WriteCHKD(Puzzle * puz, ostream_wrapper & f);
 static void WriteLTIM(Puzzle * puz, ostream_wrapper & f);
 static void WriteRUSR(Puzzle * puz, ostream_wrapper & f);
@@ -124,7 +123,6 @@ static void WriteSection(ostream_wrapper & f,
 void SaveSections(Puzzle * puz, ostream_wrapper & f)
 {
     WriteGEXT(puz, f);
-    WriteMETA(puz, f);
     WriteCHKD(puz, f);
     WriteLTIM(puz, f);
     WriteRUSR(puz, f);
@@ -173,31 +171,6 @@ void WriteGEXT(Puzzle * puz, ostream_wrapper & f)
     }
     if (hasData)
         WriteSection(f, "GEXT", data);
-}
-
-
-void WriteMETA(Puzzle * puz, ostream_wrapper & f)
-{
-    // Additional metadata
-    // This is stored as a series of null-terminated strings
-    std::string data;
-
-    const Puzzle::metamap_t & metadata = puz->GetMetadata();
-    Puzzle::metamap_t::const_iterator it;
-    for (it = metadata.begin(); it != metadata.end(); ++it)
-    {
-        if (it->first != puzT("author")
-            && it->first != puzT("title")
-            && it->first != puzT("notes")
-            && it->first != puzT("copyright")
-            && ! it->first.empty())
-        {
-            data.append(encode_utf8(it->first)).append(1, '\0');
-            data.append(encode_utf8(it->second)).append(1, '\0');
-        }
-    }
-    if (! data.empty())
-        WriteSection(f, "META", data);
 }
 
 

--- a/puz/puzstring.cpp
+++ b/puz/puzstring.cpp
@@ -253,7 +253,36 @@ string_t Trim(const string_t & str, const string_t & chars)
     return str.substr(start, end - start);
 }
 
-
+// Turn a string in snake_case into title case
+string_t TitleCase(const string_t & str)
+{
+    string_t ret(str);
+    for (size_t i = 0; i < ret.size(); ++i)
+    {
+        if (i == 0)
+        {
+#ifdef PUZ_UNICODE
+            ret[i] = towupper(str[i]);
+#else
+            ret[i] = toupper(str[i]);
+#endif
+        }
+        else if (str[i] == '_' || str[i] == ' ')
+        {
+            ret[i] = ' ';
+            ++i;
+            if (i < ret.size())
+            {
+#ifdef PUZ_UNICODE
+                ret[i] = towupper(str[i]);
+#else
+                ret[i] = toupper(str[i]);
+#endif
+            }
+        }
+    }
+    return ret;
+}
 
 std::string GetExtension(const std::string & filename)
 {

--- a/puz/puzstring.hpp
+++ b/puz/puzstring.hpp
@@ -76,6 +76,9 @@ PUZ_API string_t decode_puz(const std::string & str);
 string_t Trim(const string_t & str, const string_t & chars);
 inline string_t TrimWhitespace(const string_t & str) { return Trim(str,  puzT("\n\f\r \t")); }
 
+// Turn a string in snake_case into Title Case
+PUZ_API string_t TitleCase(const string_t & str);
+
 std::string GetExtension(const std::string & filename);
 
 string_t ToString(int number);


### PR DESCRIPTION
Previously, extra metadata outside the standard PUZ notes field was
stored in a proprietary META section that is unknown to other
applications. This would result in an inconsistent experience, where a
JPZ file with visible notes from a non-standard field would be saved as
a PUZ that would then lose visible notes when viewed in Across Lite.

With this change, we remove support for the extra META section. Instead,
when saving to PUZ, we concatenate all metadata fields which are
considered to be notes (using section headers and separators) and insert
them as plaintext into the PUZ notes field. Of course this is not a
perfect rendering, but in the most common case of having one field for
notes but which might not be the <instructions> field as XWord expects,
this does a reasonable job.

There are two main functional changes (to my knowledge):

- Metadata fields not considered notes-like are now dropped entirely
  when saving as a PUZ, instead of being stored in the custom META
  section. This feels reasonable - when saving a JPZ as a PUZ, the most
  likely reason would be to open the PUZ in another app which won't
  support the META field anyway; if the intent is to save to a file that
  can be viewed in XWord itself, there's little reason to change format.
  But if desired, we could retain the META section as long as we omit
  any notes-like metadata when doing so (to avoid repeatedly
  concatenating it to notes each time we load/save the PUZ).

- Previously, when rendering JPZ notes, the normal "notes" section would
  have a slightly different shade of gray (#eeeeee) than the other
  sections (#dddddd). The difference is subtle and I can't discern a
  major reason for it; removing this allows us to simplify the logic in
  MyFrame::ShowNotes now that we've needed to push IsNotes() down to the
  Puzzle level.

See #140