### PR TITLE
Prevent focusing on black squares within a word.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1577,7 +1577,8 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
     {
         // Check to see if the next square is part of the current word
         if (m_focusedWord &&
-            m_focusedWord->Contains(m_focusedSquare->Next(arrowDirection)))
+            m_focusedWord->Contains(m_focusedSquare->Next(arrowDirection)) &&
+            m_focusedSquare->Next(arrowDirection)->IsWhite())
         {
             SetFocusedSquare(m_focusedSquare->Next(arrowDirection),
                              m_focusedWord);


### PR DESCRIPTION
We can only focus on squares which are white (unless the puzzle is
diagramless). So when a user presses an arrow key, even if the next
square in that direction is part of the current word, we should not
attempt to focus on it unless one of those conditions match.

Fixes #146