### PR TITLE
Support black square color in jpz

### DIFF
--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -254,6 +254,7 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
                 else {
                     square->SetMissing(false);
                     square->SetBlack();
+                    square->SetColor(GetAttribute(cell, "background-color"));
                 }
             }
             else // type == puzT("letter") || type == puzT("clue")

--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -158,9 +158,16 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
             cell.append_attribute("x") = square->GetCol() + 1; // 1-based
             cell.append_attribute("y") = square->GetRow() + 1;
             if (square->IsMissing())
+            {
                 cell.append_attribute("type") = "void";
+            }
             else if (square->IsBlack() && !square->IsAnnotation())
+            {
                 cell.append_attribute("type") = "block";
+                if (square->HasColor())
+                    cell.append_attribute("background-color") =
+                        encode_utf8(square->GetHtmlColor()).c_str();
+            }
             else
             {
                 if (square->IsAnnotation())


### PR DESCRIPTION
@jpd236 any idea if this is legit for the jpz format? It's just copied from the white square section below, so it's a valid `<cell>` attribute, just not sure if it breaks crossword solver. Edit: it does work in the crosswordnexus solver at least, so that's a good sign.