### PR TITLE
Fix shift-arrow navigation with annotation squares.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1654,37 +1654,26 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
     }
     else // Shift
     {
+        // If the arrow is in the focused direction, wrap around the grid.
+        unsigned int options = AreInLine(m_focusedDirection, arrowDirection) ? 0 : puz::NO_WRAP;
         puz::GridDirection focusedDirection = 
             static_cast<puz::GridDirection>(m_focusedDirection);
-        puz::Square * newSquare = NULL;
-        if (AreInLine(m_focusedDirection, arrowDirection))
+        // Move to the next white square in the arrow direction that
+        // *could* have a word.
+        puz::Square* newSquare = NULL;
+        for (newSquare = m_focusedSquare;
+            newSquare;
+            newSquare = m_grid->FindNextSquare(newSquare, FIND_WHITE_SQUARE, arrowDirection, options))
         {
-            // Move to the next white square in the arrow direction that
-            // *could* have a word.
-            for (newSquare = m_focusedSquare;
-                 newSquare;
-                 newSquare = newSquare->Next(arrowDirection))
+            if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare, focusedDirection) != NULL)
+                && !m_focusedWord->Contains(newSquare))
             {
-                if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare, focusedDirection) != NULL)
-                    && ! m_focusedWord->Contains(newSquare))
-                {
-                    break;
-                }
+                break;
             }
-            // Find the first square in the word
-            if (newSquare)
-                newSquare = newSquare->GetWordStart(focusedDirection);
         }
-        else
-        {
-            // Move to the next white square in the arrow direction
-            newSquare = m_grid->FindNextSquare(
-                m_focusedSquare,
-                FIND_WHITE_SQUARE,
-                arrowDirection,
-                puz::NO_WRAP
-            );
-        }
+        // Find the first square in the word
+        if (newSquare)
+            newSquare = newSquare->GetWordStart(focusedDirection);
         MoveFocusedSquare(newSquare, focusedDirection);
     }
 }

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1665,7 +1665,7 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
                  newSquare;
                  newSquare = newSquare->Next(arrowDirection))
             {
-                if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare) != NULL)
+                if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare, focusedDirection) != NULL)
                     && ! m_focusedWord->Contains(newSquare))
                 {
                     break;

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -22,6 +22,7 @@
 #include <wx/tooltip.h>
 #include <list>
 #include <algorithm>
+#include <cfloat>
 #include "PuzEvent.hpp"
 #include "XGridDrawer.hpp"
 #include "messages.hpp"

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1665,7 +1665,7 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
                  newSquare;
                  newSquare = newSquare->Next(arrowDirection))
             {
-                if (newSquare->HasWord(focusedDirection)
+                if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare) != NULL)
                     && ! m_focusedWord->Contains(newSquare))
                 {
                     break;

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1661,19 +1661,26 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
         // Move to the next white square in the arrow direction that
         // *could* have a word.
         puz::Square* newSquare = NULL;
+        puz::Word* newWord = NULL;
         for (newSquare = m_focusedSquare;
             newSquare;
             newSquare = m_grid->FindNextSquare(newSquare, FIND_WHITE_SQUARE, arrowDirection, options))
         {
-            if ((newSquare->HasWord(focusedDirection) || m_puz->FindWord(newSquare, focusedDirection) != NULL)
+            puz::Word* word = m_puz->FindWord(newSquare, focusedDirection);
+            if ((newSquare->HasWord(focusedDirection) || word != NULL)
                 && !m_focusedWord->Contains(newSquare))
             {
+                newWord = word;
                 break;
             }
         }
         // Find the first square in the word
-        if (newSquare)
-            newSquare = newSquare->GetWordStart(focusedDirection);
+        if (newSquare) {
+            if (newWord)
+                newSquare = newWord->front();
+            else
+                newSquare = newSquare->GetWordStart(focusedDirection);
+        }
         MoveFocusedSquare(newSquare, focusedDirection);
     }
 }

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1703,9 +1703,9 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
                         continue;
                     for (puz::square_iterator square_it = word->begin(); square_it != word->end(); ++square_it) {
                         if (arrowDirection == puz::GetDirection(*m_focusedSquare, *square_it)) {
-                            double distance = std::sqrt(
-                                std::pow(m_focusedSquare->GetRow() - square_it->GetRow(), 2) +
-                                std::pow(m_focusedSquare->GetCol() - square_it->GetCol(), 2));
+                            double distance =
+                                std::abs(m_focusedSquare->GetRow() - square_it->GetRow()) +
+                                std::abs(m_focusedSquare->GetCol() - square_it->GetCol());
                             if (distance < closestSquareDistance) {
                                 closestSquareDistance = distance;
                                 closestSquare = &*square_it;


### PR DESCRIPTION
The intent is to navigate to the next square in a different word that
*could* be part of a word, even if it isn't. This is intended to be a
superset of all possible words, but can actually be stricter - for
example, if there is a three letter word with an annotation square in
the middle, neither of the two outer squares are considered potential
words because a word must have at least two letters.

So, in addition to accepting potential word candidates, we also accept
actual words, since some file formats support specifying words
explicitly rather than calculating them via this algorithm for potential
words.

See #146