### PR TITLE
Initial support for reading and writing UTF-8 .puz files.

### DIFF
--- a/puz/Checksummer.hpp
+++ b/puz/Checksummer.hpp
@@ -76,6 +76,9 @@ public:
         SetClueLength(m_clues.size());
     }
 
+    const std::string & GetTitle() const { return m_title; }
+    const std::string & GetAuthor() const { return m_author; }
+    const std::string & GetCopyright() const { return m_copyright; }
     const std::string & GetNotes() const { return m_notes; }
     const cluelist_t & GetClues() const { return m_clues; }
 

--- a/puz/puzstring.hpp
+++ b/puz/puzstring.hpp
@@ -72,6 +72,9 @@ namespace puz {
 PUZ_API std::string encode_puz(const string_t & str);
 PUZ_API string_t decode_puz(const std::string & str);
 
+// Whether the given string can be encoded with windows-1252.
+PUZ_API bool can_encode_puz(const string_t & str);
+
 // Utility functions
 string_t Trim(const string_t & str, const string_t & chars);
 inline string_t TrimWhitespace(const string_t & str) { return Trim(str,  puzT("\n\f\r \t")); }
@@ -100,7 +103,7 @@ enum {
 string_t escape_xml(const string_t & str);
 string_t unescape_xml(const string_t & str, int options = 0);
 
-std::string GetPuzText(const string_t & str);
+std::string GetPuzText(const string_t & str, std::string(*encode_text)(const string_t&));
 } // namespace puz
 
 #endif // PUZ_STRING_H


### PR DESCRIPTION
When reading a .puz, if the version code is 2.x (instead of 1.x), we
decode strings as UTF-8 instead of Windows-1252. This includes metadata
and clues, but not the grid itself.

When saving a .puz, if any metadata or clues uses characters which
cannot be encoded in Windows-1252, we save as a 2.x file and encode the
strings as UTF-8. This keeps backwards compatibility as wide as
possible, since not all .puz readers can handle 2.x files.

Loading/saving has been tested successfully with a basic UTF-8
character as used in the WaPo puzzle on 2021-06-20; the re-saved file
can still be loaded in Across Lite and has correctly-encoded text.
However, while the more complex example .puz with emoji clues can be
loaded, saved, and successfully loaded in Across Lite, the clues are
corrupted in the process. This needs more investigation, and may be a
bug in decode_utf8/encode_utf8 rather than the new logic here.

See #154 