### PR TITLE
Use transparent background in HTML windows

### DIFF
--- a/src/html/parse.cpp
+++ b/src/html/parse.cpp
@@ -51,7 +51,7 @@ void MyHtmlParser::InitParser(const wxString& source)
                          GetWindowInterface()
                             ? GetWindowInterface()->GetHTMLBackgroundColour()
                             : windowColour,
-                         wxHTML_CLR_BACKGROUND
+                         wxHTML_CLR_TRANSPARENT_BACKGROUND
                        )
                   );
 


### PR DESCRIPTION
The control itself draws the background. The _HTML_ background is per
cell, and a solid color background (even white) can potentially draw on
top of neighbor cells. This can appear, e.g. with the rightmost
character of italic text getting cut off.

Fixes #158