### PR TITLE
Fix regression in shift-arrow behavior on filled words.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -1656,7 +1656,8 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
     else // Shift
     {
         // If the arrow is in the focused direction, wrap around the grid.
-        unsigned int options = AreInLine(m_focusedDirection, arrowDirection) ? 0 : puz::NO_WRAP;
+        bool sameDirection = AreInLine(m_focusedDirection, arrowDirection);
+        unsigned int options = sameDirection ? 0 : puz::NO_WRAP;
         puz::GridDirection focusedDirection = 
             static_cast<puz::GridDirection>(m_focusedDirection);
         // Move to the next white square in the arrow direction that
@@ -1718,8 +1719,8 @@ XGridCtrl::OnArrow(puz::GridDirection arrowDirection, int mod)
                 newWord = closestSquareWord;
             }
         }
-        // Find the first square in the word
-        if (newSquare) {
+        // If the arrow is in the focused direction, find the first square in the word.
+        if (newSquare && sameDirection) {
             if (newWord)
                 newSquare = newWord->front();
             else


### PR DESCRIPTION
In the old logic, we only moved to the start of a word explicitly when
the arrow direction and focused direction were different:

https://github.com/mrichards42/xword/blob/cd5d08cf9cd053025a6baa92ad13b818b1e3f7c8/src/XGridCtrl.cpp#L1674

The new logic applied this unconditionally. In most cases, this seems to
have the same behavior, in that if the word being moved to has any blank
squares, we move to the first blank in the word anyway. But if the word
being moved to is full, we should stay in line with the current focused
square to avoid jumping around the grid. This makes it easier to
navigate through a filled section of the grid.

Fixes #160