### PR TITLE
Fix bug in can_encode_puz.

### DIFF
--- a/puz/puzstring.cpp
+++ b/puz/puzstring.cpp
@@ -177,9 +177,7 @@ static char unicode_to_puz(unsigned int cp)
 
 static bool can_encode_puz(unsigned int cp)
 {
-    if (cp > 255)
-        return false;
-    else if (cp < 128 || cp >= 160)
+    if (cp < 128 || (cp >= 160 && cp <= 255))
         return true;
     else
     {


### PR DESCRIPTION
As pointed out in #156, this returns false incorrectly for the Unicode
characters which are in the 128-160 range of the Cp1252 charset. This
means that XWord will unnecessarily use the less-supported 2.0 version
when saving .puz files if one of these characters are used.