### PR TITLE
Remove version check from ipuz reader.

### DIFF
--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -146,9 +146,6 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
 {
     json::Map * doc = root->AsMap();
     try {
-        // Check version
-        if (doc->PopString(puzT("version")) != puzT("http://ipuz.org/v1"))
-            throw LoadError("Unreadable ipuz version");
         // Check kind
         string_t kind = doc->PopArray(puzT("kind"))->at(0)->AsString();
         if (kind.substr(kind.size() - 2) == puzT("#1"))


### PR DESCRIPTION
v2 is generally a safe expansion on top of v1 - ipuz.org notes that some
fields have been deprecated, though the only explicit mention of
"deprecated" on the v2 doc relates to a field in Sudoku puzzles. There
may be some additional features that aren't yet supported, but these can
always be added later.

See #172