### PR TITLE
Fix namespace when saving JPZ files.

### DIFF
--- a/puz/formats/jpz/save_jpz.cpp
+++ b/puz/formats/jpz/save_jpz.cpp
@@ -70,7 +70,7 @@ void SaveJpz(Puzzle * puz, const std::string & filename, void * /* dummy */)
 
     xml::node applet = doc.append_child("crossword-compiler-applet");
     applet.append_attribute("xmlns") =
-        "http://crossword.info/xml/crossword-compiler";
+        "http://crossword.info/xml/crossword-compiler-applet";
 
     // Read settings from the saved XML Doc, otherwise provide default
     // settings.


### PR DESCRIPTION
See https://crossword.info/xml/crossword-compiler-applet.xsd which
contains the correct values.