### PR TITLE
Ensure XML characters are escaped when reading PUZ/RGZ.

### DIFF
--- a/puz/Checksummer.cpp
+++ b/puz/Checksummer.cpp
@@ -58,9 +58,9 @@ Checksummer::Checksummer(const Puzzle & puz, unsigned short version)
     else
         encode_text = encode_puz;
 
-    m_title = encode_text(puz.GetTitle());
-    m_author = encode_text(puz.GetAuthor());
-    m_copyright = encode_text(puz.GetCopyright());
+    m_title = GetPuzText(puz.GetTitle(), encode_text);
+    m_author = GetPuzText(puz.GetAuthor(), encode_text);
+    m_copyright = GetPuzText(puz.GetCopyright(), encode_text);
 
     // Notes
     // Since puz doesn't support metadata, we store all notes-like fields in the single supported

--- a/puz/formats/puz/load_puz.cpp
+++ b/puz/formats/puz/load_puz.cpp
@@ -123,9 +123,9 @@ void LoadPuz(Puzzle * puz, const std::string & filename, void * /* dummy */)
     puz->NumberGrid();
 
     // General puzzle info
-    puz->SetTitle(decode_text(f.ReadString()));
-    puz->SetAuthor(decode_text(f.ReadString()));
-    puz->SetCopyright(decode_text(f.ReadString()));
+    puz->SetTitle(escape_xml(decode_text(f.ReadString())));
+    puz->SetAuthor(escape_xml(decode_text(f.ReadString())));
+    puz->SetCopyright(escape_xml(decode_text(f.ReadString())));
 
     // Clues
     std::vector<string_t> clues;

--- a/scripts/import/rowsgarden.lua
+++ b/scripts/import/rowsgarden.lua
@@ -31,8 +31,18 @@ local function getBloomType(x, y)
     return math.floor((y + y_offset - 1) / 2) % 3
 end
 
+local function escapeXml(text)
+    local escaped = text:gsub('&', '&amp;')
+    escaped = escaped:gsub('<', '&lt;')
+    escaped = escaped:gsub('>', '&gt;')
+    return escaped
+end
+
 local function formatClue(word)
     local clue = word.clue
+
+    -- Escape XML characters
+    clue = escapeXml(clue)
 
     -- Replace *{title}* with <i>title</i>.
     clue = clue:gsub('%*([^%*]+)%*', '<i>%1</i>')
@@ -92,15 +102,15 @@ local function rowsGarden(p, contents)
     end
 
     -- Metadata
-    p.Title = doc.title
-    p.Author = doc.author
+    p.Title = escapeXml(doc.title)
+    p.Author = escapeXml(doc.author)
 
-    p.Copyright = doc.copyright
+    p.Copyright = escapeXml(doc.copyright)
     -- Add the copyright symbol (utf8)
     if #p.Copyright > 0 then p.Copyright = "\194\169 " .. p.Copyright end
 
     if type(doc.notes) == "string" then
-        p.Notes = doc.notes
+        p.Notes = escapeXml(doc.notes)
     end
 
     -- Grid and clues


### PR DESCRIPTION
XWord assumes that metadata and clue strings are valid XML/HTML when
rendering. This works fine for JPZ since the input is itself a valid XML
file, but may not be the case for other formats.

The clues and notepad were already being escaped when reading PUZ files
(and unescaped when writing them); we should do the same for the title,
author, and notes. Similarly, when reading RGZ files, we should escape
XML for any free-form text.

See #182