### PR TITLE
Support cell background colors in iPuz files.

### DIFF
--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -138,7 +138,23 @@ void ipuzParser::SetStyle(Square & square, json::Value * style_value)
     if (barred.find(puzT("B")) != string_t::npos)
         square.m_bars[BAR_BOTTOM] = true;
 
-    // TODO: colors
+    // Color
+    string_t color = style->GetString(puzT("color"), puzT(""));
+    if (!color.empty()) {
+        if (color.length() == 6) {
+            // Six-digit hex value.
+            square.SetColor(color);
+        }
+        else {
+            // Integer indicating an arbitrary app-defined color.
+            // The spec recommends supporting "at least 16", with 0 as black and others as non-black.
+            // For now, just support 0 and treat others as "highlight".
+            if (color == puzT("0"))
+                square.SetColor(0, 0, 0);
+            else
+                square.SetHighlight();
+        }
+    }
 }
 
 


### PR DESCRIPTION
iPuz supports two types of color declarations. Hex colors are
straightforward and fully supported. Puzzles can also use arbitrary
integers, which are app-defined values. For example, and app can define
0 = Black, 1 = Blue, 2 = Red, etc. This method seems less likely to be
used in practice, and it is non-trivial to define a palette that would
work well for arbitrary puzzles and user preferences. So for simplicity,
we treat 0 as Black per the spec recommendation, and everything else as
equivalent to "highlighted" (shaded gray).

Fixes #186 