### PR TITLE
Escape XML by default in metadata and clue text.

### DIFF
--- a/lua/luapuz/bind/luapuz_puz.cpp
+++ b/lua/luapuz/bind/luapuz_puz.cpp
@@ -254,6 +254,7 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
             puz::string_t number = luapuz_checkstring_t(L, -2);
             puz::string_t text;
             puz::Word word;
+            bool is_html = false;
             if (lua_istable(L, -1))
             {
                 // Look for data:
@@ -275,6 +276,12 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
                 if (! lua_isnil(L, -1))
                     luapuz_checkWord(L, -1, &word);
                 lua_pop(L, 1);
+
+                // is_html
+                lua_getfield(L, -1, "is_html");
+                if (! lua_isnil(L, -1))
+                    is_html = luapuz_checkboolean(L, -1);
+                lua_pop(L, 1);
             }
             else if (lua_isstring(L, -1))
             {
@@ -285,7 +292,7 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
                 luaL_error(L, "puz::Clue, table, or string expected for clue; got %s", luaL_typename(L, -1));
             }
 
-            clues->push_back(puz::Clue(number, text, word));
+            clues->push_back(puz::Clue(number, text, word, is_html));
         }
 
         /* removes 'value'; keeps 'key' for next iteration */

--- a/lua/luapuz/bind/luapuz_puz_Puzzle.cpp
+++ b/lua/luapuz/bind/luapuz_puz_Puzzle.cpp
@@ -326,13 +326,15 @@ static int Puzzle_GetMeta(lua_State * L)
     luapuz_pushstring_t(L, returns);
     return 1;
 }
-// void SetMeta(puz::string_t name, puz::string_t value)
+// void SetMeta(puz::string_t name, puz::string_t value, bool is_html = false)
 static int Puzzle_SetMeta(lua_State * L)
 {
     puz::Puzzle * puzzle = luapuz_checkPuzzle(L, 1);
+    int argCount = lua_gettop(L);
     puz::string_t name = luapuz_checkstring_t(L, 2);
     puz::string_t value = luapuz_checkstring_t(L, 3);
-    puzzle->SetMeta(name, value);
+    bool is_html = (argCount >= 4 ? luapuz_checkboolean(L, 4) : false);
+    puzzle->SetMeta(name, value, is_html);
     return 0;
 }
 // bool HasMeta(puz::string_t name)
@@ -352,12 +354,14 @@ static int Puzzle_GetAuthor(lua_State * L)
     luapuz_pushstring_t(L, returns);
     return 1;
 }
-// void SetAuthor(puz::string_t author)
+// void SetAuthor(puz::string_t author, bool is_html = false)
 static int Puzzle_SetAuthor(lua_State * L)
 {
     puz::Puzzle * puzzle = luapuz_checkPuzzle(L, 1);
+    int argCount = lua_gettop(L);
     puz::string_t author = luapuz_checkstring_t(L, 2);
-    puzzle->SetAuthor(author);
+    bool is_html = (argCount >= 3 ? luapuz_checkboolean(L, 3) : false);
+    puzzle->SetAuthor(author, is_html);
     return 0;
 }
 // puz::string_t GetTitle()
@@ -368,12 +372,14 @@ static int Puzzle_GetTitle(lua_State * L)
     luapuz_pushstring_t(L, returns);
     return 1;
 }
-// void SetTitle(puz::string_t title)
+// void SetTitle(puz::string_t title, bool is_html = false)
 static int Puzzle_SetTitle(lua_State * L)
 {
     puz::Puzzle * puzzle = luapuz_checkPuzzle(L, 1);
+    int argCount = lua_gettop(L);
     puz::string_t title = luapuz_checkstring_t(L, 2);
-    puzzle->SetTitle(title);
+    bool is_html = (argCount >= 3 ? luapuz_checkboolean(L, 3) : false);
+    puzzle->SetTitle(title, is_html);
     return 0;
 }
 // puz::string_t GetCopyright()
@@ -384,12 +390,14 @@ static int Puzzle_GetCopyright(lua_State * L)
     luapuz_pushstring_t(L, returns);
     return 1;
 }
-// void SetCopyright(puz::string_t copyright)
+// void SetCopyright(puz::string_t copyright, bool is_html = false)
 static int Puzzle_SetCopyright(lua_State * L)
 {
     puz::Puzzle * puzzle = luapuz_checkPuzzle(L, 1);
+    int argCount = lua_gettop(L);
     puz::string_t copyright = luapuz_checkstring_t(L, 2);
-    puzzle->SetCopyright(copyright);
+    bool is_html = (argCount >= 3 ? luapuz_checkboolean(L, 3) : false);
+    puzzle->SetCopyright(copyright, is_html);
     return 0;
 }
 // puz::string_t GetNotes()
@@ -400,12 +408,14 @@ static int Puzzle_GetNotes(lua_State * L)
     luapuz_pushstring_t(L, returns);
     return 1;
 }
-// void SetNotes(puz::string_t notes)
+// void SetNotes(puz::string_t notes, bool is_html = false)
 static int Puzzle_SetNotes(lua_State * L)
 {
     puz::Puzzle * puzzle = luapuz_checkPuzzle(L, 1);
+    int argCount = lua_gettop(L);
     puz::string_t notes = luapuz_checkstring_t(L, 2);
-    puzzle->SetNotes(notes);
+    bool is_html = (argCount >= 3 ? luapuz_checkboolean(L, 3) : false);
+    puzzle->SetNotes(notes, is_html);
     return 0;
 }
 // int GetTime()

--- a/lua/luapuz/bind/puz_defs.lua
+++ b/lua/luapuz/bind/puz_defs.lua
@@ -283,12 +283,18 @@ class{"Puzzle", header="puz/Puzzle.hpp", cppheader="luapuz_puz_Puzzle_helpers.hp
     property{"Grid &", "Grid"}
     func{"GetMetadata", returns="Puzzle::metamap_t"}
     func{"GetMeta", arg("puz::string_t", "name"), returns="puz::string_t"}
-    func{"SetMeta", arg("puz::string_t", "name"), arg("puz::string_t", "value")}
+    func{"SetMeta", arg("puz::string_t", "name"),
+                    arg("puz::string_t", "value"),
+                    arg("bool", "is_html", "false")}
     func{"HasMeta", arg("puz::string_t", "name"), returns="bool"}
-    property{"puz::string_t", "Author"}
-    property{"puz::string_t", "Title"}
-    property{"puz::string_t", "Copyright"}
-    property{"puz::string_t", "Notes"}
+    func{"GetAuthor", returns="puz::string_t"}
+    func{"SetAuthor", arg("puz::string_t", "author"), arg("bool", "is_html", "false")}
+    func{"GetTitle", returns="puz::string_t"}
+    func{"SetTitle", arg("puz::string_t", "title"), arg("bool", "is_html", "false")}
+    func{"GetCopyright", returns="puz::string_t"}
+    func{"SetCopyright", arg("puz::string_t", "copyright"), arg("bool", "is_html", "false")}
+    func{"GetNotes", returns="puz::string_t"}
+    func{"SetNotes", arg("puz::string_t", "notes"), arg("bool", "is_html", "false")}
     property{"int", "Time"}
     func{"IsTimerRunning", returns="bool"}
     func{"SetTimerRunning", arg("bool", "running")}

--- a/lua/luapuz/bind/puz_overrides.lua
+++ b/lua/luapuz/bind/puz_overrides.lua
@@ -527,6 +527,7 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
             puz::string_t number = luapuz_checkstring_t(L, -2);
             puz::string_t text;
             puz::Word word;
+            bool is_html = false;
             if (lua_istable(L, -1))
             {
                 // Look for data:
@@ -548,6 +549,12 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
                 if (! lua_isnil(L, -1))
                     luapuz_checkWord(L, -1, &word);
                 lua_pop(L, 1);
+
+                // is_html
+                lua_getfield(L, -1, "is_html");
+                if (! lua_isnil(L, -1))
+                    is_html = luapuz_checkboolean(L, -1);
+                lua_pop(L, 1);
             }
             else if (lua_isstring(L, -1))
             {
@@ -558,7 +565,7 @@ void luapuz_checkClueList(lua_State * L, int index, puz::ClueList * clues)
                 luaL_error(L, "puz::Clue, table, or string expected for clue; got %s", luaL_typename(L, -1));
             }
 
-            clues->push_back(puz::Clue(number, text, word));
+            clues->push_back(puz::Clue(number, text, word, is_html));
         }
 
         /* removes 'value'; keeps 'key' for next iteration */

--- a/puz/Clue.cpp
+++ b/puz/Clue.cpp
@@ -37,9 +37,12 @@ void Clue::SetNumber(int _number)
     number = ToString(_number);
 }
 
-void Clue::SetText(const string_t & _text)
+void Clue::SetText(const string_t & _text, const bool _is_html)
 {
-    text = unescape_xml(_text);
+    if (_is_html)
+        text = _text;
+    else
+        text = escape_xml(_text);
 }
 
 // ---------------------------------------------------------------------------

--- a/puz/Clue.hpp
+++ b/puz/Clue.hpp
@@ -37,37 +37,40 @@ class PUZ_API Clue
     friend class ClueList;
 public:
     explicit Clue(const string_t & num_ = puzT(""),
-                  const string_t & text_ = puzT(""))
+                  const string_t & text_ = puzT(""),
+                  const bool is_html_ = false)
     {
         SetNumber(num_);
-        SetText(text_);
+        SetText(text_, is_html_);
     }
 
     explicit Clue(const string_t & num_,
                   const string_t & text_,
-                  Word word_)
+                  Word word_,
+                  const bool is_html_ = false)
         : word(word_)
     {
         SetNumber(num_);
-        SetText(text_);
+        SetText(text_, is_html_);
     }
 
-    explicit Clue(int num_, const string_t & text_ = puzT(""))
+    explicit Clue(int num_, const string_t & text_ = puzT(""), const bool is_html_ = false)
     {
         SetNumber(num_);
-        SetText(text_);
+        SetText(text_, is_html_);
     }
 
     explicit Clue(int num_,
                   const string_t & text_,
-                  Word word_)
+                  Word word_,
+                  const bool is_html_ = false)
         : word(word_)
     {
         SetNumber(num_);
-        SetText(text_);
+        SetText(text_, is_html_);
     }
 
-    void SetText  (const string_t & text_);
+    void SetText(const string_t & text_, const bool is_html_ = false);
     void SetNumber(const string_t & num_);
     void SetNumber(int num_);
     void SetWord(const Word & word_) { word = word_; }

--- a/puz/Puzzle.hpp
+++ b/puz/Puzzle.hpp
@@ -92,27 +92,37 @@ public:
         metamap_t::const_iterator it = m_metadata.find(name);
         return it != m_metadata.end();
     }
-    void SetMeta(const string_t & name, const string_t & value)
+    void SetMeta(const string_t & name, const string_t & value, const bool is_html = false)
     {
         if (value.empty())
             m_metadata.erase(name);
-        else
+        else if (is_html)
             m_metadata[name] = value;
+        else
+            m_metadata[name] = escape_xml(value);
     }
     const metamap_t & GetMetadata() const { return m_metadata; }
     metamap_t & GetMetadata() { return m_metadata; }
 
     const string_t & GetTitle() const { return GetMeta(puzT("title")); }
-    void SetTitle(const string_t & title) { SetMeta(puzT("title"), title); }
+    void SetTitle(const string_t & title, const bool is_html = false) {
+        SetMeta(puzT("title"), title, is_html);
+    }
 
     const string_t & GetAuthor() const { return GetMeta(puzT("author")); }
-    void SetAuthor(const string_t & author) { SetMeta(puzT("author"), author); }
+    void SetAuthor(const string_t & author, const bool is_html = false) {
+        SetMeta(puzT("author"), author, is_html);
+    }
 
     const string_t & GetCopyright() const { return GetMeta(puzT("copyright")); }
-    void SetCopyright(const string_t & copyright) { SetMeta(puzT("copyright"), copyright); }
+    void SetCopyright(const string_t & copyright, const bool is_html = false) {
+        SetMeta(puzT("copyright"), copyright, is_html);
+    }
 
     const string_t & GetNotes() const { return GetMeta(puzT("notes")); }
-    void SetNotes(const string_t & notes) { SetMeta(puzT("notes"), notes); }
+    void SetNotes(const string_t & notes, const bool is_html = false) {
+        SetMeta(puzT("notes"), notes, is_html);
+    }
 
     // Get a vector of all notes-like metadata for display.
     const std::vector<std::pair<string_t, string_t> > GetAllNotes() const;
@@ -162,6 +172,7 @@ public:
     // and all clue numbers have a matching square number
     void GenerateWords();
     // Writes the clues in "Across Lite" order given a vector of clues.
+    // Note: This assumes plaintext clues, not HTML.
     void SetAllClues(const std::vector<string_t> & clues);
     // Was this puzzle set up with NumberGrid and NumberClues?
     // Clues may only be "Across" and "Down", words must start and end

--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -181,14 +181,14 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
     }
 
     // Metadata
-    puz->SetTitle(doc->PopString(puzT("title"), puzT("")));
-    puz->SetAuthor(doc->PopString(puzT("author"), puzT("")));
-    puz->SetCopyright(doc->PopString(puzT("copyright"), puzT("")));
+    puz->SetTitle(doc->PopString(puzT("title"), puzT("")), /* is_html */ true);
+    puz->SetAuthor(doc->PopString(puzT("author"), puzT("")), /* is_html */ true);
+    puz->SetCopyright(doc->PopString(puzT("copyright"), puzT("")), /* is_html */ true);
     string_t notes = doc->PopString(puzT("notes"), puzT(""));
     if (! notes.empty())
-        puz->SetNotes(notes);
+        puz->SetNotes(notes, /* is_html */ true);
     else
-        puz->SetNotes(doc->PopString(puzT("intro"), puzT("")));
+        puz->SetNotes(doc->PopString(puzT("intro"), puzT("")), /* is_html */ true);
 
     // Read the styles into a style map
     if (doc->Contains(puzT("styles")))
@@ -318,12 +318,13 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
             {
                 json::Value * clueVal = (*clue_it);
                 if (clueVal->IsSimple())
-                    cluelist.push_back(Clue(puzT(""), clueVal->AsString()));
+                    cluelist.push_back(Clue(puzT(""), clueVal->AsString(), /* is_html */ true));
                 else if (clueVal->IsArray())
                 {
                     json::Array * clue = (*clue_it)->AsArray();
                     cluelist.push_back(Clue(clue->GetString(0),
-                                            clue->GetString(1)));
+                                            clue->GetString(1),
+                                            /* is_html */ true));
                 }
                 else
                 {
@@ -340,7 +341,8 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
 
                     cluelist.push_back(Clue(
                         clue->GetString(puzT("number"), puzT("")),
-                        text
+                        text,
+                        /* is_html */ true
                     ));
                 }
             }

--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -189,22 +189,22 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
     for (meta = meta.first_child(); meta; meta = meta.next_sibling())
     {
         if (strcmp(meta.name(), "creator") == 0)
-            puz->SetAuthor(GetTrimmedInnerXML(meta));
+            puz->SetAuthor(GetTrimmedInnerXML(meta), /* is_html */ true);
         else
-            puz->SetMeta(decode_utf8(meta.name()), GetTrimmedInnerXML(meta));
+            puz->SetMeta(decode_utf8(meta.name()), GetTrimmedInnerXML(meta), /* is_html */ true);
         // Can be title, creator, copyright, editor, publisher, created,
         // rights, identifier, description
     }
-    puz->SetNotes(GetInnerXML(puzzle, "instructions"));
+    puz->SetNotes(GetInnerXML(puzzle, "instructions"), /* is_html */ true);
 
     if (puz->GetTitle().empty())
-        puz->SetTitle(GetTrimmedInnerXML(applet, "title"));
+        puz->SetTitle(GetTrimmedInnerXML(applet, "title"), /* is_html */ true);
     if (puz->GetCopyright().empty())
-        puz->SetCopyright(GetTrimmedInnerXML(applet, "copyright"));
+        puz->SetCopyright(GetTrimmedInnerXML(applet, "copyright"), /* is_html */ true);
 
     xml::node completion = applet.child("applet-settings").child("completion");
     if (completion) {
-        puz->SetMeta(puzT("completion"), GetTrimmedInnerXML(completion));
+        puz->SetMeta(puzT("completion"), GetTrimmedInnerXML(completion), /* is_html */ true);
     }
 
     // Grid
@@ -379,7 +379,7 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
                 if (! format.empty())
                     text.append(puzT(" (")).append(format).append(puzT(")"));
                 string_t number = GetAttribute(clue, "number");
-                list.push_back(Clue(number, text, it->second));
+                list.push_back(Clue(number, text, it->second, /* is_html */ true));
             }
             puz->SetClueList(key, list);
             hasClueList = true;

--- a/puz/formats/puz/load_puz.cpp
+++ b/puz/formats/puz/load_puz.cpp
@@ -123,9 +123,9 @@ void LoadPuz(Puzzle * puz, const std::string & filename, void * /* dummy */)
     puz->NumberGrid();
 
     // General puzzle info
-    puz->SetTitle(escape_xml(decode_text(f.ReadString())));
-    puz->SetAuthor(escape_xml(decode_text(f.ReadString())));
-    puz->SetCopyright(escape_xml(decode_text(f.ReadString())));
+    puz->SetTitle(decode_text(f.ReadString()));
+    puz->SetAuthor(decode_text(f.ReadString()));
+    puz->SetCopyright(decode_text(f.ReadString()));
 
     // Clues
     std::vector<string_t> clues;
@@ -143,7 +143,7 @@ void LoadPuz(Puzzle * puz, const std::string & filename, void * /* dummy */)
 
     // Notes
     std::string notes = f.ReadString();
-    puz->SetNotes(escape_xml(decode_text(notes)));
+    puz->SetNotes(decode_text(notes));
 
     puz->SetOk(true);
 

--- a/puz/formats/puz/load_puz.cpp
+++ b/puz/formats/puz/load_puz.cpp
@@ -136,7 +136,7 @@ void LoadPuz(Puzzle * puz, const std::string & filename, void * /* dummy */)
     for (size_t i = 0; i < num_clues; ++i)
     {
         cksum_clues.push_back(f.ReadString());
-        clues.push_back(escape_xml(decode_text(cksum_clues.back())));
+        clues.push_back(decode_text(cksum_clues.back()));
     }
 
     puz->SetAllClues(clues);

--- a/scripts/import/amuselabs.lua
+++ b/scripts/import/amuselabs.lua
@@ -22,8 +22,8 @@ local function importJSON(p, doc)
   end
 
   -- Metadata
-  p.Title = doc.title
-  p.Author = doc.author
+  p:SetTitle(doc.title, --[[ is_html ]] true)
+  p:SetAuthor(doc.author, --[[ is_html ]] true)
 
   -- Grid
   local g = p.Grid
@@ -89,7 +89,8 @@ local function importJSON(p, doc)
     table.insert(clues[clue_k], {
         number = placedWord.clueNum,
         text = placedWord.clue.clue,
-        word = make_word(g, placedWord)
+        word = make_word(g, placedWord),
+        is_html = true
       })
   end
   p:SetClueList("Across", clues.across)

--- a/scripts/import/rowsgarden.lua
+++ b/scripts/import/rowsgarden.lua
@@ -102,15 +102,15 @@ local function rowsGarden(p, contents)
     end
 
     -- Metadata
-    p.Title = escapeXml(doc.title)
-    p.Author = escapeXml(doc.author)
+    p.Title = doc.title
+    p.Author = doc.author
 
-    p.Copyright = escapeXml(doc.copyright)
+    p.Copyright = doc.copyright
     -- Add the copyright symbol (utf8)
     if #p.Copyright > 0 then p.Copyright = "\194\169 " .. p.Copyright end
 
     if type(doc.notes) == "string" then
-        p.Notes = escapeXml(doc.notes)
+        p.Notes = doc.notes
     end
 
     -- Grid and clues
@@ -168,6 +168,7 @@ local function rowsGarden(p, contents)
                         number = s.Number,
                         text = row_clue,
                         word = row_word,
+                        is_html = true
                     })
                 end
 
@@ -183,7 +184,8 @@ local function rowsGarden(p, contents)
                         word = {
                             g[{x - 2, y}], g[{x - 1, y}], g[{x, y}],
                             g[{x, y + 1}], g[{x - 1, y + 1}], g[{x - 2, y + 1}]
-                        }
+                        },
+                        is_html = true
                     })
                 end
             end


### PR DESCRIPTION
Previously, this was done on an ad-hoc basis in certain formats/fields,
but not all, which could lead to inconsistent/incorrect handling of
special characters like & and <.

Now, all metadata fields and clues default to assuming that the provided
strings are plaintext and escape XML characters so that XWord (which
renders them as HTML) renders them correctly. Functions take an
additional, optional is_html bool parameter which can be set to true if
the input should be left unchanged (since it is already valid HTML).
This is used for JPZ, IPUZ, Amuse Labs imports, and Rows Garden clues
(where we convert * to italic tags, and escape the rest of the clue
manually).

Fixes #182 