### PR TITLE
Fix crash in nextblank with void cells.

### DIFF
--- a/scripts/nextblank/init.lua
+++ b/scripts/nextblank/init.lua
@@ -8,7 +8,7 @@ local function find_next_blank(square)
     return grid:FindSquare(
         square or grid:First(),
         function(s)
-            return s:IsBlank()
+            return s:IsBlank() and s:IsWhite()
         end
     )
 end


### PR DESCRIPTION
nextblank logic needs to skip void cells, since it is impossible to set
focus on such cells. So we only include "white" cells (where user input
is possible).

Fixes #190