### PR TITLE
Always draw annotation square text

### DIFF
--- a/src/XGridDrawer.cpp
+++ b/src/XGridDrawer.cpp
@@ -652,13 +652,14 @@ XGridDrawer::DrawSquare(wxDC & adc,
 
     // Draw square's text (bottom and center to avoid conflicts with numbers)
     if ((HasFlag(DRAW_USER_TEXT) && ! square.IsBlank()) ||
-        (HasFlag(DRAW_SOLUTION) && ! square.IsSolutionBlank()))
+        (HasFlag(DRAW_SOLUTION) && ! square.IsSolutionBlank()) ||
+        square.IsAnnotation())
     {
         dc.SetTextForeground(textColor);
         wxString text;
         bool isSymbol = false;
         // User Text
-        if (HasFlag(DRAW_USER_TEXT))
+        if (HasFlag(DRAW_USER_TEXT) || square.IsAnnotation())
         {
             if (square.HasTextSymbol())
             {


### PR DESCRIPTION
This failed when printing a blank grid (which sets neither DRAW_USER_TEXT nor DRAW_SOLUTION flags).

Bug reported in an email this morning.

@jpd236 since I haven't done much (anything?) with annotation squares, mind giving this a quick peek to see I missed anything obvious? I think this is a pretty simple fix, but you never know.