### PR TITLE
Blend square background color with focus/selection colors.

### DIFF
--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -587,7 +587,7 @@ XGridCtrl::DrawSquare(wxDC & dc, const puz::Square & square, const wxColour & co
     if (color == wxNullColour || &color == &EraseColor)
         m_drawer.DrawSquare(dc, square);
     else
-        m_drawer.DrawSquare(dc, square, color, GetPenColor());
+        m_drawer.DrawSquare(dc, square, color, GetPenColor(), /* blendBackground= */ true);
 
     // Reset the drawing mode
     if (drawOutline)

--- a/src/XGridDrawer.hpp
+++ b/src/XGridDrawer.hpp
@@ -171,7 +171,8 @@ public:
 
     void DrawSquare(wxDC & dc, const puz::Square & square,
                     const wxColour & bgColor,
-                    const wxColour & textColor);
+                    const wxColour & textColor,
+                    const bool blendBackground = false);
 
     void DrawSquare(wxDC & dc, const puz::Square & square);
 


### PR DESCRIPTION
Previously, focused or selected cells would be colored with the appropriate color regardless of the cell background, which causes shaded cells to lose their contrast against other cells in the puzzle. This can interfere with solving, as it is important to be able to tell which cells are shaded in a focused word.

We adopt an approach from crosswordnexus/html5-crossword-solver#91: if a focused or selected cell has a non-white background, we blend the background color with the focus/selection color to determine the cell color. We darken the background color when blending to ensure sufficient contrast.

This should resolve much of #178. Cell background images will still be hidden when focused/selected; these are significantly rarer and harder to handle.