### PR TITLE
Retain clue list panel width across restarts.

### DIFF
--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -1434,6 +1434,8 @@ MyFrame::ManageWindows()
                   .Hide()
                   .Caption(_T("Notes"))
                   .Name(_T("Notes")));
+
+    ShowClues();
 }
 
 


### PR DESCRIPTION
While AUI is mysterious, what appeared to be happening is that the panels were added in two separate update phases: first the grid, clue prompt, and notes as part of MyFrame::ManageWindows, and then the clue list panels later on as part of MyFrame::ShowClues. While the clue panel's best width property does get restored from the prior config when it is created in this second phase, AUI does not seem to respect it, capping it at a maximum value. I'd speculate this is because the grid has expanded to take the space that would have been occupied by the clue panel, and would thus need its sized reduced in tandem with adding the clue panels back to the layout.

In any case, forcing a call to ShowClues as part of ManageWindows adds the clue panels a bit earlier on, which appears to be enough to get the setting to stick across restarts.