### PR TITLE
Improve handling of puzzles without solutions.

### DIFF
--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -309,6 +309,10 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
             }
         });
     }
+    else
+    {
+        puz->GetGrid().SetFlag(FLAG_NO_SOLUTION);
+    }
 
     // User grid
     if (doc->Contains(puzT("saved")))

--- a/puz/formats/jpz/load_jpz.cpp
+++ b/puz/formats/jpz/load_jpz.cpp
@@ -226,6 +226,7 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
         }
 
         // Grid cells
+        bool has_solution = false;
         xml::node cell = RequireChild(grid_node, "cell");
         for (; cell; cell = cell.next_sibling("cell"))
         {
@@ -260,7 +261,10 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
             else // type == puzT("letter") || type == puzT("clue")
             {
                 square->SetMissing(false);
-                square->SetSolution(GetAttribute(cell, "solution"));
+                string_t solution = GetAttribute(cell, "solution");
+                square->SetSolution(solution);
+                if (!solution.empty())
+                    has_solution = true;
                 square->SetText(GetAttribute(cell, "solve-state"));
                 if (type == puzT("clue"))
                     square->SetAnnotation(true);
@@ -314,6 +318,9 @@ bool jpzParser::DoLoadPuzzle(Puzzle * puz, xml::document & doc)
                     image.child_value("encoded-image"));
             }
         }
+
+        if (!has_solution)
+            grid.SetFlag(FLAG_NO_SOLUTION);
     }
 
     // Words

--- a/src/XGridCtrl.cpp
+++ b/src/XGridCtrl.cpp
@@ -340,23 +340,23 @@ XGridCtrl::UnscrambleSolution(unsigned short key)
 // Helper for IsCorrect and GetStats
 CorrectStatus GetCorrectStatus(const puz::Grid * grid, bool correct)
 {
-    // We *can* test scrambled puzzles!  Not sure why I didn't think of
-    // this before.  (Inspired by Alex Boisvert:
-    // http://alexboisvert.com/software.html#check)
-    if (correct)
+    if (!grid->HasSolution())
+    {
+        return UNCHECKABLE_PUZZLE;
+    }
+    else if (correct)
     {
         return CORRECT_PUZZLE;
     }
     else if (grid->IsScrambled())
     {
+        // We *can* test scrambled puzzles!  Not sure why I didn't think of
+        // this before.  (Inspired by Alex Boisvert:
+        // http://alexboisvert.com/software.html#check)
         if (grid->CheckScrambledGrid())
             return CORRECT_PUZZLE;
         else
             return INCORRECT_PUZZLE;
-    }
-    else if (! grid->HasSolution())
-    {
-        return UNCHECKABLE_PUZZLE;
     }
     else
     {
@@ -403,7 +403,7 @@ XGridCtrl::GetStats(GridStats * stats) const
             if (square->IsBlank())
             {
                 ++stats->blank;
-                if (square->IsSolutionBlank())
+                if (m_grid->HasSolution() && square->IsSolutionBlank())
                     ++stats->blank_correct;
             }
             // If the puzzle is correct so far, and without blanks (that do


### PR DESCRIPTION
- Support IPUZ/JPZ files without solutions, leveraging the existing PUZ grid flag. For IPUZ files, we can look at whether the solution grid is present. For JPZ files, we look at whether any letter squares have non-empty solutions.
- Respect the "no solution" grid flag when evaluating the completion status. This prevents us from thinking that the grid is correctly filled when it is fully empty.