### PR TITLE
Support square with a value in ipuz.

### DIFF
--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -282,6 +282,7 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
                 val = map->GetString(puzT("cell"), empty_str);
                 if (map->Contains(puzT("style")))
                     SetStyle(square, map->Get(puzT("style")));
+                square.SetText(map->GetString(puzT("value"), puzT("")));
             }
             if (val == block_str)
                 square.SetSolution(square.Black);


### PR DESCRIPTION
We treat these identically to jpz files with hint="true" and prefill the user's solution with the square's solution.

Fixes #213