### PR TITLE
Fix Mac builds by pinning to an older Xcode version.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,6 +97,7 @@ for:
 
   # Build XWord
   build_script:
+    - sudo xcode-select -s /Applications/Xcode-13.4.1.app
     - xcodebuild -project build/xcode4/XWord.xcodeproj -configuration "$CONFIGURATION" build
     - if [ "$CONFIGURATION" == "Release" ]; then sed -e "s/{VERSION}/${XWORD_VERSION}/" -e "s/{OS_FILE}/XWord-macOS.zip/" dist/packages_template.lua > dist/packages_mac.lua; fi
 


### PR DESCRIPTION
Available versions taken from:
https://www.appveyor.com/docs/macos-images-software/

Xcode 14.2 (the current default) requires setting
MACOSX_DEPLOYMENT_TARGET to 10.13 or higher; XWord currently uses 10.10. Eventually we will need to raise the minimum (and drop support for 10.10-10.12), but this should keep things working for the time being.