### PR TITLE
Clean up distinction between clue list direction and display title.

### DIFF
--- a/puz/formats/ipuz/load_ipuz.cpp
+++ b/puz/formats/ipuz/load_ipuz.cpp
@@ -405,7 +405,14 @@ bool ipuzParser::DoLoadPuzzle(Puzzle * puz, json::Value * root)
                     cluelist.push_back(outClue);
                 }
             }
-            puz->SetClueList(cl_it->first, cluelist);
+            // Directions can optionally specify a display string, after a ':'.
+            int colon_pos = cl_it->first.find(':');
+            if (colon_pos == std::string::npos) {
+                puz->SetClueList(cl_it->first, cluelist);
+            } else {
+                cluelist.SetTitle(cl_it->first.substr(colon_pos + 1));
+                puz->SetClueList(cl_it->first.substr(0, colon_pos), cluelist);
+            }
         }
     }
 

--- a/puz/formats/xpf/save_xpf.cpp
+++ b/puz/formats/xpf/save_xpf.cpp
@@ -188,12 +188,12 @@ void SaveXPF(Puzzle * puz, const std::string & filename, void * /* dummy */)
                 }
                 else // diagramless
                 {
-                    puz::string_t title = cluelist.GetTitle();
-                    if (title == puzT("Across"))
+                    puz::string_t direction = clues_it->first;
+                    if (direction == puzT("Across"))
                         clue.append_attribute("Dir") = "Across";
-                    else if (title == puzT("Down"))
+                    else if (direction == puzT("Down"))
                         clue.append_attribute("Dir") = "Down";
-                    else if (title == puzT("Diagonal"))
+                    else if (direction == puzT("Diagonal"))
                         clue.append_attribute("Dir") = "Diagonal";
                     else
                         throw ConversionError("XPF clues must be Across, Down, or Diagonal");

--- a/src/MyFrame.cpp
+++ b/src/MyFrame.cpp
@@ -909,12 +909,14 @@ MyFrame::ShowClues()
         puz::Clues::iterator it;
         for (it = m_puz.GetClues().begin() ; it != m_puz.GetClues().end(); ++it)
         {
-            wxString label = puz2wx(it->first);
+            wxString direction = puz2wx(it->first);
+            // Clue list titles can contain HTML, so parse out the plain text.
+            wxString label = PlainTextHtmlParser::StripTags(puz2wx(it->second.GetTitle()));
             // Name the pane
             wxString id;
-            if (label == _T("Across"))
+            if (direction == _T("Across"))
                 id = _T("ClueList1");
-            else if (label == _T("Down"))
+            else if (direction == _T("Down"))
                 id = _T("ClueList2");
             else
                 id = wxString::Format(_T("ClueList%d"), cluelist_id++);
@@ -945,9 +947,9 @@ MyFrame::ShowClues()
             clues->SetClueList(&it->second);
             if (no_clues)
                 clues->ClearClueList();
-            else if (label == _T("Across") && m_toolMgr.IsChecked(ID_DOWNS_ONLY))
+            else if (direction == _T("Across") && m_toolMgr.IsChecked(ID_DOWNS_ONLY))
                 clues->ClearClueList();
-            m_clues[label] = clues;
+            m_clues[direction] = clues;
         }
     }
 
@@ -2797,9 +2799,9 @@ MyFrame::UpdateClues()
             // Figure out if this clue is focused or crossing
             const bool is_focused =
                 (direction == puz::ACROSS &&
-                 cluelist.GetTitle() == puzT("Across")) ||
+                 it->first == puzT("Across")) ||
                 (direction == puz::DOWN &&
-                 cluelist.GetTitle() == puzT("Down"));
+                 it->first == puzT("Down"));
 
             // Find the clue
             for (clues_it = cluelist.begin(); clues_it != cluelist.end(); ++clues_it)

--- a/src/printout.cpp
+++ b/src/printout.cpp
@@ -244,7 +244,7 @@ MyPrintout::GetHTML()
         html << _T("<table cellspacing=0 cellpadding=1 border=0>");
         // Heading
         html << _T("<tr><th colspan=2 align=\"left\"><font size=\"+1\"><b>")
-                    << BreakLine(dc, puz2wx(clues_it->first), m_columnWidth)
+                    << BreakLine(dc, puz2wx(clues_it->second.GetTitle()), m_columnWidth)
                << _T("</b></font></th></tr>");
         puz::ClueList::const_iterator it;
         for (it = clues_it->second.begin(); it != clues_it->second.end(); ++it)


### PR DESCRIPTION
- Use the direction (string key in Clues map) when we need a semantically-meaningful value.
- Use the title (ClueList#getTitle) when we need a value to be displayed to the user.
- Handle ipuz files that contain both a direction and display title. For other formats, the two values are identical.

In the UI, the clue list pane and printout have been updated to use the display title.

When saving JPZ files, we use the display title; if we have to choose one, this feels like the better choice, since we shouldn't need to rely heavily on the semantic meaning when the words are explicitly given, and the display title is what the user sees.

Note that the Lua scripts have not been updated, as the display title is not yet exposed there, and this will be a slightly more involved change (see #220).

See #219