### PR TITLE
Fix build-luajit.sh to point to the git repository.

### DIFF
--- a/build-luajit.sh
+++ b/build-luajit.sh
@@ -31,9 +31,8 @@ fi
 
 # Check to see if the cache directory is empty
 if [ ! -d "$INSTALL_PATH/lib" ]; then
-  curl -fsSL -o LuaJIT-$LUAJIT_VERSION.tar.gz https://luajit.org/download/LuaJIT-2.0.5.tar.gz
-  tar -xzf LuaJIT-$LUAJIT_VERSION.tar.gz
-  cd LuaJIT-$LUAJIT_VERSION/src
+  git clone -b v$LUAJIT_VERSION --depth 1 https://github.com/LuaJIT/LuaJIT.git
+  cd LuaJIT/src
   eval $BUILD_COMMAND
   mkdir -p $INSTALL_PATH/lib
   eval $INSTALL_COMMAND


### PR DESCRIPTION
Per https://luajit.org/download.html, release tarballs have been taken down. For deterministic results, it seems best to point to a specific tag in the Git repository, and for the moment we can just use the same version we were using. In the future, we could consider following the recommendation to point to a newer version or at least a fixed commit on a newer branch.

We use the official GitHub mirror rather than the main repository in order to support "--depth=1" to avoid fetching the entire repository instead of just the branch we care about.